### PR TITLE
feat: Configure API::V1 with JSON format support

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -14,6 +14,9 @@ exclude_paths:
 detectors:
   IrresponsibleModule:
     enabled: false
+  UncommunicativeModuleName:
+    exclude:
+      - API::V1
 
 directories:
   'app/validators':

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class BaseController < ApplicationController
+
+      # TODO: Authentication
+      # TODO: Authorization
+      # TODO: Handle Errors
+      # TODO: Render JSON
+
+      before_action :ensure_json_request_format
+
+      private
+
+      def ensure_json_request_format
+        unless request.format.json?
+          render json: { message: I18n.t('errors.request.format.only_json_accepted') }, status: :not_acceptable
+        end
+      end
+
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,6 +13,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,10 @@
 #       enabled: "ON"
 
 en:
+  errors:
+    request:
+      format:
+        only_json_accepted: 'Only JSON is accepted'
   activerecord:
     errors:
       models:

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
       "npm run rubocop:fix",
       "bundle exec rails_best_practices",
       "bundle exec reek",
-      "bundle exec rake traceroute",
-      "bundle exec brakeman --no-pager --only-files"
+      "bundle exec rake traceroute"
     ],
     "Gemfile, Gemfile.lock": [
       "npm run rubocop:fix",

--- a/spec/requests/api/v1/base_controller_spec.rb
+++ b/spec/requests/api/v1/base_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::BaseController, type: :controller do
+  controller(API::V1::BaseController) do
+    def index
+      render json: { message: 'Dummy action' }
+    end
+  end
+
+  before do
+    routes.draw do
+      namespace :api do
+        namespace :v1 do
+          resources :base, only: [ :index ]
+        end
+      end
+    end
+  end
+
+  describe 'Request format' do
+    context 'when JSON' do
+      before do
+        request.headers['Accept'] = Mime[:json].to_s
+      end
+
+      it 'allows request' do
+        get :index
+
+        expect(response).to have_http_status(:ok)
+        expect(json_symbolize[:message]).to eq('Dummy action')
+      end
+    end
+
+    context 'when non-JSON' do
+      before do
+        request.headers['Accept'] = Mime[:html].to_s
+      end
+
+      it 'responds with HTTP 406 - Not Acceptable' do
+        get :index
+
+        expect(response).to have_http_status(:not_acceptable)
+        expect(json_symbolize[:message]).to eq(I18n.t('errors.request.format.only_json_accepted'))
+      end
+    end
+  end
+end

--- a/spec/support/json_helper.rb
+++ b/spec/support/json_helper.rb
@@ -5,15 +5,25 @@ module JsonHelper
   def json
     @json ||= begin
       body = response.body
-      JSON.parse(body) if body.present?
+
+      if response.status == 204
+        return {}
+      elsif body.blank?
+        raise "Blank response body"
+      else
+        JSON.parse(body)
+      end
+    rescue JSON::ParserError
+      raise "Invalid JSON response body: #{body}"
     end
   end
 
   def json_symbolize
-    @json_symbolize ||= begin
-      body = response.body
-      JSON.parse(body, symbolize_names: true) if body.present?
-    end
+    @json_symbolize ||= json.deep_symbolize_keys
+  end
+
+  def json_with_indifferent_access
+    @json_with_indifferent_access ||= json.with_indifferent_access
   end
 
 end


### PR DESCRIPTION
- Setup basic API V1 structure with base controller
- Ensure that only JSON format is responded
- Add specs
- Improve spec JSON helper
- Remove brakeman from pre-commit hooks, not properly working with lint-staged

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Configure API V1 to support only JSON format by adding a base controller with a format check. Enhance the JSON helper in tests to better handle response parsing and error scenarios. Update inflection rules to recognize 'API' as an acronym. Remove Brakeman from pre-commit hooks due to issues with lint-staged.

New Features:
- Introduce a base controller for API V1 that ensures only JSON format is accepted in requests.

Enhancements:
- Improve the JSON helper in specs to handle different response scenarios and raise errors for invalid JSON.

Chores:
- Remove Brakeman from pre-commit hooks due to compatibility issues with lint-staged.

<!-- Generated by sourcery-ai[bot]: end summary -->