### PR TITLE
feat: Handle standard error for API requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,10 @@ Layout/BlockAlignment:
   EnforcedStyleAlignWith: start_of_block
 Layout/EndAlignment:
   EnforcedStyleAlignWith: keyword
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
 
 # Style
 Style/StringLiterals:

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -9,13 +9,15 @@ module API
       # TODO: Handle Errors
       # TODO: Render JSON
 
+      include ErrorHandler
+
       before_action :ensure_json_request_format
 
       private
 
       def ensure_json_request_format
         unless request.format.json?
-          render json: { message: I18n.t('errors.request.format.only_json_accepted') }, status: :not_acceptable
+          respond_with_error(status: :not_acceptable, i18n_key: 'api.v1.errors.request.format.only_json_accepted')
         end
       end
 

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ErrorHandler
+
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from StandardError, with: :handle_error
+
+    def route_not_found
+      raise ActionController::RoutingError
+    end
+  end
+
+  private
+
+  ERROR_MAPPINGS = {
+    StandardError => [ :internal_server_error, 'api.v1.errors.response.internal_server_error' ].freeze,
+    RuntimeError => [ :internal_server_error, 'api.v1.errors.response.internal_server_error' ].freeze,
+    ActiveRecord::RecordNotFound => [ :not_found, 'api.v1.errors.response.record_not_found' ].freeze,
+    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.errors.response.unprocessable_content' ].freeze,
+    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
+    ActionController::ParameterMissing => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
+    ActionController::RoutingError => [ :not_found, 'api.v1.errors.response.record_not_found' ].freeze
+  }.freeze
+
+  def handle_error(exception)
+    status, i18n_key = ERROR_MAPPINGS.fetch(exception.class, ERROR_MAPPINGS[StandardError])
+
+    respond_with_error(status: status, i18n_key: i18n_key)
+  end
+
+  def respond_with_error(status:, i18n_key:)
+    render(
+      json: {
+        error: {
+          code: Rack::Utils::SYMBOL_TO_STATUS_CODE.fetch(status),
+          status: status.to_s,
+          message: I18n.t(i18n_key)
+        }
+      },
+      status: status
+    )
+  end
+
+end

--- a/app/serializers/hash_serializer.rb
+++ b/app/serializers/hash_serializer.rb
@@ -22,7 +22,7 @@ class HashSerializer
   def self.validate_value_type(value)
     unless value.is_a?(Hash) || value.is_a?(String)
       raise SerializationTypeMismatch,
-            "Expected 'Hash' or 'String' value but got #{value.class} => #{value.inspect}"
+        "Expected 'Hash' or 'String' value but got #{value.class} => #{value.inspect}"
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,10 +28,18 @@
 #       enabled: "ON"
 
 en:
-  errors:
-    request:
-      format:
-        only_json_accepted: 'Only JSON is accepted'
+  api:
+    v1:
+      errors:
+        request:
+          format:
+            only_json_accepted: 'Only JSON requests are accepted'
+        response:
+          ok: Success
+          internal_server_error: 'Internal server error'
+          unprocessable_content: 'Unprocessable content'
+          bad_request: 'Bad request'
+          record_not_found: 'Resource not found'
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,13 @@ Rails.application.routes.draw do
   # TODO: Add admin constraints
   mount Sidekiq::Web => '/sidekiq'
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  namespace :api do
+    namespace :v1 do
+      # This must be the last route definition under the namespace
+      # to catch-all route to handle missing routes
+      match '*unmatched_route', to: 'base#route_not_found', via: :all
+    end
+  end
+
+  # We can consider universal catch-all route here later
 end

--- a/spec/requests/api/v1/base_controller_spec.rb
+++ b/spec/requests/api/v1/base_controller_spec.rb
@@ -2,32 +2,34 @@
 
 require 'rails_helper'
 
-RSpec.describe API::V1::BaseController, type: :controller do
-  controller(API::V1::BaseController) do
-    def index
-      render json: { message: 'Dummy action' }
-    end
-  end
-
+RSpec.describe API::V1::BaseController, type: :request do
   before do
-    routes.draw do
+    Rails.application.routes.draw do
       namespace :api do
         namespace :v1 do
           resources :base, only: [ :index ]
         end
       end
     end
+
+    API::V1::BaseController.class_eval do
+      def index
+        render json: { message: 'Dummy action' }
+      end
+    end
   end
+
+  after { Rails.application.reload_routes! }
 
   describe 'Request format' do
     context 'when JSON' do
       before do
-        request.headers['Accept'] = Mime[:json].to_s
+        headers = { 'Accept' => Mime[:json].to_s }
+
+        get '/api/v1/base', headers: headers
       end
 
-      it 'allows request' do
-        get :index
-
+      it 'allows request and responds with JSON' do
         expect(response).to have_http_status(:ok)
         expect(json_symbolize[:message]).to eq('Dummy action')
       end
@@ -35,15 +37,47 @@ RSpec.describe API::V1::BaseController, type: :controller do
 
     context 'when non-JSON' do
       before do
-        request.headers['Accept'] = Mime[:html].to_s
+        headers = { 'Accept' => Mime[:html].to_s }
+
+        get '/api/v1/base', headers: headers
       end
 
       it 'responds with HTTP 406 - Not Acceptable' do
-        get :index
-
         expect(response).to have_http_status(:not_acceptable)
-        expect(json_symbolize[:message]).to eq(I18n.t('errors.request.format.only_json_accepted'))
+        expect(json_symbolize[:error][:message]).to eq(I18n.t('api.v1.errors.request.format.only_json_accepted'))
       end
     end
+  end
+
+  describe 'Error handlers' do
+    shared_examples 'error handler' do |error_class, status, message_key|
+      before do
+        headers = { 'Accept' => Mime[:json].to_s }
+
+        allow_any_instance_of(API::V1::BaseController).to receive(:index).and_raise(error_class)
+
+        get '/api/v1/base', headers: headers
+      end
+
+      it "handles #{error_class} correctly" do
+        expect(response).to have_http_status(status)
+
+        error_json = json_symbolize[:error]
+        expect(error_json[:code]).to eq(Rack::Utils::SYMBOL_TO_STATUS_CODE[status])
+        expect(error_json[:message]).to eq(I18n.t(message_key))
+        expect(error_json[:status]).to eq(status.to_s)
+      end
+    end
+
+    it_behaves_like 'error handler', StandardError, :internal_server_error,
+      'api.v1.errors.response.internal_server_error'
+    it_behaves_like 'error handler', RuntimeError, :internal_server_error,
+      'api.v1.errors.response.internal_server_error'
+    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.errors.response.record_not_found'
+    it_behaves_like 'error handler', ActiveRecord::RecordNotSaved, :unprocessable_content,
+      'api.v1.errors.response.unprocessable_content'
+    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.errors.response.bad_request'
+    it_behaves_like 'error handler', ActionController::ParameterMissing.new(:param_name), :bad_request,
+      'api.v1.errors.response.bad_request'
   end
 end


### PR DESCRIPTION
- Setup common error handler and responder
- Rescue from few common errors
- Add catch all route to handle missing endpoints
- Create errors in I18n
- Write specs
- Configure some missing layout cops for Rubocop

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement a standardized error handling mechanism for API requests by introducing a common error handler module. Enhance route configuration to include a catch-all route for missing endpoints and update I18n for error messages. Improve code quality by configuring additional Rubocop layout cops and expand test coverage to validate error handling.

New Features:
- Introduce a common error handler module to manage standard errors for API requests, providing consistent error responses.

Enhancements:
- Add a catch-all route in the API namespace to handle missing endpoints, improving error handling for undefined routes.
- Enhance the I18n configuration to include error messages for various HTTP status codes, ensuring better localization support.

Build:
- Configure additional layout cops in Rubocop to enforce consistent code formatting, specifically for parameter and argument alignment.

Tests:
- Add new test cases to verify the handling of various errors in the API, ensuring that the correct HTTP status codes and messages are returned.

<!-- Generated by sourcery-ai[bot]: end summary -->