### PR TITLE
feat: Extract API version from path and improve API error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ npm-debug.log*
 .npm
 .npmrc
 .node_repl_history
+
+# IDE
+.vscode
+.idea

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -10,6 +10,7 @@ module API
       # TODO: Render JSON
 
       include ErrorHandler
+      include Versionable
 
       before_action :ensure_json_request_format
 

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -6,22 +6,23 @@ module ErrorHandler
 
   included do
     rescue_from StandardError, with: :handle_error
+  end
 
-    def route_not_found
-      raise ActionController::RoutingError
-    end
+  def route_not_found
+    raise ActionController::RoutingError
   end
 
   private
 
   ERROR_MAPPINGS = {
-    StandardError => [ :internal_server_error, 'api.v1.errors.response.internal_server_error' ].freeze,
-    RuntimeError => [ :internal_server_error, 'api.v1.errors.response.internal_server_error' ].freeze,
+    StandardError => [ :internal_server_error, 'api.v1.errors.response.standard_error' ].freeze,
+    RuntimeError => [ :internal_server_error, 'api.v1.errors.response.runtime_error' ].freeze,
+    ActionController::BadRequest => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
     ActiveRecord::RecordNotFound => [ :not_found, 'api.v1.errors.response.record_not_found' ].freeze,
-    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.errors.response.unprocessable_content' ].freeze,
-    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
-    ActionController::ParameterMissing => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
-    ActionController::RoutingError => [ :not_found, 'api.v1.errors.response.record_not_found' ].freeze
+    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.errors.response.record_not_saved' ].freeze,
+    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.errors.response.record_invalid' ].freeze,
+    ActionController::ParameterMissing => [ :bad_request, 'api.v1.errors.response.parameter_missing' ].freeze,
+    ActionController::RoutingError => [ :not_found, 'api.v1.errors.response.routing_error' ].freeze
   }.freeze
 
   def handle_error(exception)
@@ -30,16 +31,16 @@ module ErrorHandler
     respond_with_error(status: status, i18n_key: i18n_key)
   end
 
-  def respond_with_error(status:, i18n_key:)
+  def respond_with_error(status:, i18n_key:, i18n_variables: {})
     render(
       json: {
         error: {
           code: Rack::Utils::SYMBOL_TO_STATUS_CODE.fetch(status),
           status: status.to_s,
-          message: I18n.t(i18n_key)
+          message: I18n.t(i18n_key, **i18n_variables)
         }
       },
-      status: status
+      status:
     )
   end
 

--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Versionable
+
+  extend ActiveSupport::Concern
+
+  class APIVersionMismatchError < StandardError; end
+
+  included do
+    before_action :set_api_version
+    before_action :ensure_api_version
+  end
+
+  private
+
+  attr_reader :api_version
+
+  def set_api_version
+    @api_version ||= begin
+      # /api/v1/users -> ['', 'api', 'v1', 'users'] -> 'v1'
+      version = request.path.split('/').third
+
+      APIVersion.new(version)
+    end
+  end
+
+  def ensure_api_version
+    unless api_version.valid? && api_version.public_send("#{expected_api_version}?")
+      handle_version_mismatch
+    end
+  end
+
+  def expected_api_version
+    @expected_api_version ||= self.class.module_parent.name.split('::').second.downcase
+  end
+
+  def handle_version_mismatch
+    version = api_version.version
+
+    if Rails.env.local?
+      raise APIVersionMismatchError,
+        "Controller version mismatch: expected #{expected_api_version}, but got #{version}"
+    else
+      Rails.logger.error(
+        "Controller version mismatch: expected #{expected_api_version}, but got #{version}"
+      )
+
+      raise ActionController::BadRequest
+    end
+  end
+
+end

--- a/app/models/api_version.rb
+++ b/app/models/api_version.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class APIVersion
+
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  VERSIONS = %w[v1].freeze
+
+  attribute :version, :string
+
+  validates :version, presence: true, inclusion: { in: VERSIONS }
+
+  def initialize(version)
+    super(version: version.to_s.downcase)
+  end
+
+  VERSIONS.each do |ver|
+    define_method("#{ver}?") do
+      version == ver
+    end
+  end
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,10 +36,14 @@ en:
             only_json_accepted: 'Only JSON requests are accepted'
         response:
           ok: Success
-          internal_server_error: 'Internal server error'
-          unprocessable_content: 'Unprocessable content'
+          standard_error: 'Internal server error'
+          runtime_error: 'Internal server error'
           bad_request: 'Bad request'
+          record_not_saved: 'Unprocessable content: Record not saved'
           record_not_found: 'Resource not found'
+          routing_error: 'Resource not found'
+          record_invalid: 'Invalid record'
+          parameter_missing: 'Required parameters missing'
   activerecord:
     errors:
       models:

--- a/spec/requests/api/v1/base_controller_spec.rb
+++ b/spec/requests/api/v1/base_controller_spec.rb
@@ -3,7 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe API::V1::BaseController, type: :request do
-  before do
+  before(:all) do
+    API::V1::BaseController.class_eval do
+      def index
+        render json: { message: 'Dummy action' }
+      end
+    end
+
     Rails.application.routes.draw do
       namespace :api do
         namespace :v1 do
@@ -11,15 +17,9 @@ RSpec.describe API::V1::BaseController, type: :request do
         end
       end
     end
-
-    API::V1::BaseController.class_eval do
-      def index
-        render json: { message: 'Dummy action' }
-      end
-    end
   end
 
-  after { Rails.application.reload_routes! }
+  after(:all) { Rails.application.reload_routes! }
 
   describe 'Request format' do
     context 'when JSON' do
@@ -47,37 +47,5 @@ RSpec.describe API::V1::BaseController, type: :request do
         expect(json_symbolize[:error][:message]).to eq(I18n.t('api.v1.errors.request.format.only_json_accepted'))
       end
     end
-  end
-
-  describe 'Error handlers' do
-    shared_examples 'error handler' do |error_class, status, message_key|
-      before do
-        headers = { 'Accept' => Mime[:json].to_s }
-
-        allow_any_instance_of(API::V1::BaseController).to receive(:index).and_raise(error_class)
-
-        get '/api/v1/base', headers: headers
-      end
-
-      it "handles #{error_class} correctly" do
-        expect(response).to have_http_status(status)
-
-        error_json = json_symbolize[:error]
-        expect(error_json[:code]).to eq(Rack::Utils::SYMBOL_TO_STATUS_CODE[status])
-        expect(error_json[:message]).to eq(I18n.t(message_key))
-        expect(error_json[:status]).to eq(status.to_s)
-      end
-    end
-
-    it_behaves_like 'error handler', StandardError, :internal_server_error,
-      'api.v1.errors.response.internal_server_error'
-    it_behaves_like 'error handler', RuntimeError, :internal_server_error,
-      'api.v1.errors.response.internal_server_error'
-    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.errors.response.record_not_found'
-    it_behaves_like 'error handler', ActiveRecord::RecordNotSaved, :unprocessable_content,
-      'api.v1.errors.response.unprocessable_content'
-    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.errors.response.bad_request'
-    it_behaves_like 'error handler', ActionController::ParameterMissing.new(:param_name), :bad_request,
-      'api.v1.errors.response.bad_request'
   end
 end

--- a/spec/requests/concerns/error_handler_spec.rb
+++ b/spec/requests/concerns/error_handler_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API Error Handler Concern', type: :request do
+  before(:all) do
+    module API
+      module V1
+        class TestController < ApplicationController
+
+          include ErrorHandler
+
+          def index = render json: { message: 'Dummy action' }
+
+        end
+      end
+    end
+
+    Rails.application.routes.draw do
+      namespace :api do
+        namespace :v1 do
+          resources :test, only: [ :index ]
+        end
+      end
+    end
+  end
+
+  after(:all) { Rails.application.reload_routes! }
+
+  describe 'Error handlers' do
+    shared_examples 'error handler' do |error_class, status, message_key|
+      before do
+        headers = { 'Accept' => Mime[:json].to_s }
+
+        allow_any_instance_of(API::V1::TestController).to receive(:index).and_raise(error_class)
+
+        get '/api/v1/test', headers: headers
+      end
+
+      it "handles #{error_class} correctly" do
+        expect(response).to have_http_status(status)
+
+        error_json = json_symbolize[:error]
+        expect(error_json[:code]).to eq(Rack::Utils::SYMBOL_TO_STATUS_CODE.fetch(status))
+        expect(error_json[:message]).to eq(I18n.t(message_key))
+        expect(error_json[:status]).to eq(status.to_s)
+      end
+    end
+
+    it_behaves_like 'error handler', StandardError, :internal_server_error,
+      'api.v1.errors.response.standard_error'
+    it_behaves_like 'error handler', RuntimeError, :internal_server_error,
+      'api.v1.errors.response.runtime_error'
+    it_behaves_like 'error handler', ActionController::BadRequest, :bad_request, 'api.v1.errors.response.bad_request'
+    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.errors.response.record_not_found'
+    it_behaves_like 'error handler', ActiveRecord::RecordNotSaved, :unprocessable_content,
+      'api.v1.errors.response.record_not_saved'
+    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.errors.response.record_invalid'
+    it_behaves_like 'error handler', ActionController::ParameterMissing.new(:param_name), :bad_request,
+      'api.v1.errors.response.parameter_missing'
+  end
+end

--- a/spec/requests/concerns/versionable_spec.rb
+++ b/spec/requests/concerns/versionable_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "API Versionable Concern", type: :request do
+  before(:all) do
+    module API
+      module V1
+        class TestVersionableController < ApplicationController
+
+          include Versionable
+
+          def index = render json: { message: "API version is #{api_version.version}" }
+
+        end
+      end
+    end
+
+    Rails.application.routes.draw do
+      namespace :api do
+        get 'v2/test_versionable', action: :index, controller: 'v1/test_versionable'
+
+        namespace :v1 do
+          get '/test_versionable', to: 'test_versionable#index'
+        end
+      end
+    end
+  end
+
+  after(:all) do
+    Rails.application.reload_routes!
+  end
+
+  let(:headers) {  { 'Accept' => Mime[:json].to_s } }
+
+  context 'when valid version' do
+    it 'returns success' do
+      get '/api/v1/test_versionable', headers: headers
+
+      expect(response).to have_http_status(:success)
+      expect(json_symbolize[:message]).to eq("API version is v1")
+    end
+  end
+
+  context 'when invalid version' do
+    it 'returns API version mismatch error' do
+      expect {
+        get '/api/v2/test_versionable', headers: headers
+      }.to raise_error(Versionable::APIVersionMismatchError)
+    end
+  end
+end


### PR DESCRIPTION
- Extract API version number from path
- Make it available globally
- Improve Error handler
- Write specs

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Extract API version from the request path and make it globally available. Enhance the error handler with more specific error mappings and messages. Introduce new modules and models to support API versioning, and update tests to reflect these changes.

New Features:
- Introduce a mechanism to extract and validate API version from the request path using a new Versionable module and APIVersion model.

Enhancements:
- Improve the error handler by refining error mappings and adding more specific error messages for different exceptions.

Tests:
- Update and refine test cases in the base_controller_spec to align with the new error handling and API versioning logic.

<!-- Generated by sourcery-ai[bot]: end summary -->