### PR TITLE
feat: Setup JSON serializer using Alba and Oj

### DIFF
--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BaseSerializer
+
+  include Alba::Resource
+
+  transform_keys :lower_camel
+
+end

--- a/config/initializers/alba.rb
+++ b/config/initializers/alba.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Alba.backend = :oj_rails # faster than active_support
+
+# Auto infers attributes from objects
+# Intentionally disabled considering security implications of accidentally exposing sensitive attributes
+# Better to be explicit about what is being included in responses
+# Alba.enable_inference!(with: :active_support)

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Oj.optimize_rails
+
+default_options = {
+  mode: :compat # Standard JSON compatibility
+}
+
+# Pretty print in development
+default_options[:indent] = 2 if Rails.env.development?
+
+Oj.default_options = Oj.default_options.merge(default_options)

--- a/spec/serializers/base_serializer_spec.rb
+++ b/spec/serializers/base_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BaseSerializer do
+  subject(:json_serialized) { DummySerializer.new(dummy_record).serialize }
+
+  let(:dummy_record) { Struct.new(:some_attribute).new('some value') }
+
+  let!(:dummy_serializer) do
+    class DummySerializer < BaseSerializer
+
+      root_key!
+      attributes :some_attribute
+
+    end
+  end
+
+  it "transforms key to lowerCame case" do
+    expect(json_serialized).to eq("{\"dummy\":{\"someAttribute\":\"some value\"}}")
+  end
+end


### PR DESCRIPTION
- Extract API version number from path
- Make it available globally
- Improve Error handler
- Write specs

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Extract the API version from the request path and make it globally accessible. Enhance the API error handler for improved error management. Configure JSON serialization with Oj and Alba for better performance and security.

New Features:
- Extract API version number from the request path and make it globally available.

Enhancements:
- Improve the API error handler for better error management.

Build:
- Add an initializer for the Oj gem to optimize JSON handling in Rails, with pretty printing enabled in development.
- Add an initializer for the Alba gem, setting the backend to Oj for improved performance and disabling attribute inference for security.

<!-- Generated by sourcery-ai[bot]: end summary -->