### PR TITLE
feat: Add global timestamp iso8601 serializer helper

### DIFF
--- a/app/serializers/concerns/timestamps_formatter.rb
+++ b/app/serializers/concerns/timestamps_formatter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Adds method to serialize timestamp attributes like created_at, updated_at into ISO 8601 format
+module TimestampsFormatter
+
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Usage:
+    # timestamps :created_at
+    # timestamps :created_at, :updated_at
+    # timestamps :created_at, :updated_at, :deleted_at
+    def timestamps(*attrs)
+      attrs.each { |attr| add_timestamp_attribute(attr) }
+    end
+
+    private
+
+    def add_timestamp_attribute(attr)
+      attribute(attr) { |object| object.public_send(attr)&.iso8601 }
+    end
+  end
+
+end

--- a/spec/serializers/base_serializer_spec.rb
+++ b/spec/serializers/base_serializer_spec.rb
@@ -7,14 +7,17 @@ RSpec.describe BaseSerializer do
 
   let(:dummy_record) { Struct.new(:some_attribute).new('some value') }
 
-  let!(:dummy_serializer) do
-    class DummySerializer < BaseSerializer
-
-      root_key!
-      attributes :some_attribute
-
-    end
+  before do
+    Object.const_set(
+      :DummySerializer,
+      Class.new(BaseSerializer) do
+        root_key!
+        attributes :some_attribute
+      end
+    )
   end
+
+  after { Object.send(:remove_const, :DummySerializer) }
 
   it "transforms key to lowerCame case" do
     expect(json_serialized).to eq("{\"dummy\":{\"someAttribute\":\"some value\"}}")

--- a/spec/serializers/concerns/timestamps_formatter_spec.rb
+++ b/spec/serializers/concerns/timestamps_formatter_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TimestampsFormatter do
+  subject(:parsed_record) { JSON.parse(DummySerializer.new(dummy_record).serialize).symbolize_keys }
+
+  before do
+    Object.const_set(
+      :DummySerializer,
+      Class.new do
+        include Alba::Resource
+        include TimestampsFormatter
+
+        timestamps :created_at, :updated_at
+      end
+    )
+  end
+
+  after { Object.send(:remove_const, :DummySerializer) }
+
+  context 'when valid timestamps' do
+    let(:dummy_record) { Struct.new(:created_at, :updated_at).new(Time.now, Time.now) }
+
+    it 'formats created_at in ISO 8601 format' do
+      expect(parsed_record[:created_at]).to eq(dummy_record.created_at.iso8601)
+    end
+
+    it 'formats updated_at in ISO 8601 format' do
+      expect(parsed_record[:updated_at]).to eq(dummy_record.updated_at.iso8601)
+    end
+  end
+
+  context 'when invalid timestamps' do
+    let(:dummy_record) { Struct.new(:created_at, :updated_at).new(nil, Time.now) }
+
+    it 'handles nil timestamp' do
+      expect(parsed_record[:created_at]).to be_nil
+      expect(parsed_record[:updated_at]).to eq(dummy_record.updated_at.iso8601)
+    end
+  end
+end


### PR DESCRIPTION
- Add concern to provide convenient way to format timestamp attributes to iso8601 globally
- Write spec

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a concern module to provide a convenient way to format timestamp attributes to ISO 8601 globally, and include a corresponding test to ensure its functionality.

New Features:
- Introduce a concern module to globally format timestamp attributes like created_at and updated_at into ISO 8601 format.

Tests:
- Add a spec to test the new timestamp formatting functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->