### PR TITLE
feat: Introduce Users API

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -9,6 +9,7 @@ module API
       # TODO: Handle Errors
       # TODO: Render JSON
 
+      # Depending on API V2 design, this can be moved to Application controller as needed
       include ErrorHandler
       include Versionable
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class API::V1::UsersController < API::V1::BaseController
+
+  def index
+    users = User.all
+
+    render json: API::V1::UserSerializer.new(users).serialize
+  end
+
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class API::V1::UserSerializer < BaseSerializer
+
+  include TimestampsFormatter
+
+  attributes :id, :email, :first_name, :last_name, :full_name, :status
+
+  attributes :archival_reason, if: ->(user) { user.archived? }
+
+  attribute :preferences do |user|
+    user.preferences.with_indifferent_access
+  end
+
+  timestamps :created_at, :updated_at
+
+end

--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -4,6 +4,8 @@ class BaseSerializer
 
   include Alba::Resource
 
-  transform_keys :lower_camel
+  root_key!
+
+  transform_keys :lower_camel, root: true
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :users, only: [ :index ]
+
       # This must be the last route definition under the namespace
       # to catch-all route to handle missing routes
       match '*unmatched_route', to: 'base#route_not_found', via: :all

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,7 +28,6 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     email { Faker::Internet.unique.email }
     status { :active }
-    preferences { { theme: 'system' } }
 
     trait :pending do
       status { :pending }

--- a/spec/requests/api/v1/base_controller_spec.rb
+++ b/spec/requests/api/v1/base_controller_spec.rb
@@ -23,24 +23,17 @@ RSpec.describe API::V1::BaseController, type: :request do
 
   describe 'Request format' do
     context 'when JSON' do
-      before do
-        headers = { 'Accept' => Mime[:json].to_s }
-
-        get '/api/v1/base', headers: headers
-      end
+      before { get '/api/v1/base', headers: { 'Accept' => Mime[:json].to_s } }
 
       it 'allows request and responds with JSON' do
-        expect(response).to have_http_status(:ok)
+        expect(response).to be_successful
+
         expect(json_symbolize[:message]).to eq('Dummy action')
       end
     end
 
     context 'when non-JSON' do
-      before do
-        headers = { 'Accept' => Mime[:html].to_s }
-
-        get '/api/v1/base', headers: headers
-      end
+      before { get '/api/v1/base', headers: { 'Accept' => Mime[:html].to_s } }
 
       it 'responds with HTTP 406 - Not Acceptable' do
         expect(response).to have_http_status(:not_acceptable)

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::UsersController, type: :request do
+  describe '#index' do
+    subject(:get_users) { get api_v1_users_path, headers: { 'Accept' => Mime[:json].to_s } }
+
+    let!(:users) { create_list(:user, collection_size) }
+
+    let(:collection_size) { 4 }
+    let(:root_key) { :users }
+
+    let(:expected_keys) do
+      [
+        :id,
+        :email,
+        :firstName,
+        :lastName,
+        :fullName,
+        :status,
+        :preferences,
+        :createdAt,
+        :updatedAt
+      ]
+    end
+
+    describe 'response' do
+      before { get_users }
+
+      it 'responds with http success' do
+        expect(response).to be_successful
+      end
+
+      it 'serializes users collection with expected attributes' do
+        expect(json_symbolize).to have_key(root_key)
+
+        users = json_symbolize[root_key]
+
+        expect(users.size).to eq(collection_size)
+        expect(users.first.keys).to match_array(expected_keys)
+      end
+    end
+
+    context 'when user is archived' do
+      let(:archival_reason) { 'dummy reason' }
+      let!(:archived_user) { create(:user, status: :archived, archival_reason:) }
+
+      it 'includes archival_reason in the serialized output' do
+        get_users
+
+        archived_user_json = json_symbolize[root_key].find { |user| user[:id] == archived_user.id }
+
+        expect(archived_user_json[:status]).to eq(archived_user.status)
+        expect(archived_user_json).to have_key(:archivalReason)
+        expect(archived_user_json[:archivalReason]).to eq(archival_reason)
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v1/user_serializer_spec.rb
+++ b/spec/serializers/api/v1/user_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::UserSerializer, type: :serializer do
+  subject(:serialized_json) { JSON.parse(described_class.new(user).serialize) }
+
+  let(:user) { create(:user, preferences: { theme: 'dark' }) }
+
+  let(:expected_user_data) do
+    {
+      "user" => {
+        "id" => user.id,
+        "firstName" => user.first_name,
+        "lastName" => user.last_name,
+        "fullName" => user.full_name,
+        "email" => user.email,
+        "status" => user.status,
+        "preferences" => { "theme" => "dark" },
+        "createdAt" => user.created_at.iso8601,
+        "updatedAt" => user.updated_at.iso8601
+      }
+    }
+  end
+
+  it 'includes expected attributes' do
+    expect(serialized_json).to eq(expected_user_data)
+  end
+end


### PR DESCRIPTION
- /api/v1/users API to serve user collection along with controller
- Add User serializer
- Write request and serializer specs

TODO:

- Add pagination
- OpenAPI documentation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new Users API endpoint to serve user data, including a UserSerializer for formatting the response. Add tests to ensure the API and serialization work as expected.

New Features:
- Introduce a new Users API endpoint at /api/v1/users to serve the user collection.

Enhancements:
- Add a UserSerializer to format user data with attributes like id, email, first_name, last_name, full_name, status, and preferences.

Tests:
- Add request and serializer specs to test the new Users API and serialization logic.

<!-- Generated by sourcery-ai[bot]: end summary -->