### PR TITLE
feat: Setup rswag for API testing and OpenAPI documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
-# Omakase Ruby styling for Rails
 inherit_gem:
+  # Omakase Ruby styling for Rails
   rubocop-rails-omakase: rubocop.yml
+  rswag-specs: .rubocop_rspec_alias_config.yml
 
 require:
   # - rubocop-performance # included in omakase

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,10 @@ gem 'strong_migrations'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+# OpenAPI/Swagger
+gem 'rswag-api'
+gem 'rswag-ui'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug'
@@ -82,6 +86,8 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec-parameterized'
   gem 'rspec-rails'
+  # Write Request specs with OpenAPI documentation
+  gem 'rswag-specs'
   # Simple one-liner tests for common Rails functionality
   gem 'shoulda-matchers'
   # Test data and mocks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       reline (>= 0.4.2)
     jaro_winkler (1.6.0)
     json (2.7.2)
+    json-schema (4.3.1)
+      addressable (>= 2.8)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -383,6 +385,17 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
+    rswag-api (2.14.0)
+      activesupport (>= 5.2, < 8.0)
+      railties (>= 5.2, < 8.0)
+    rswag-specs (2.14.0)
+      activesupport (>= 5.2, < 8.0)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 5.2, < 8.0)
+      rspec-core (>= 2.14)
+    rswag-ui (2.14.0)
+      actionpack (>= 5.2, < 8.0)
+      railties (>= 5.2, < 8.0)
     rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -565,6 +578,9 @@ DEPENDENCIES
   rspec
   rspec-parameterized
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop
   rubocop-factory_bot
   rubocop-performance

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -19,7 +19,7 @@ module API
 
       def ensure_json_request_format
         unless request.format.json?
-          respond_with_error(status: :not_acceptable, i18n_key: 'api.v1.errors.request.format.only_json_accepted')
+          respond_with_error(status: :not_acceptable, i18n_key: 'api.v1.request.errors.format.only_json_accepted')
         end
       end
 

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -15,14 +15,14 @@ module ErrorHandler
   private
 
   ERROR_MAPPINGS = {
-    StandardError => [ :internal_server_error, 'api.v1.errors.response.standard_error' ].freeze,
-    RuntimeError => [ :internal_server_error, 'api.v1.errors.response.runtime_error' ].freeze,
-    ActionController::BadRequest => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
-    ActiveRecord::RecordNotFound => [ :not_found, 'api.v1.errors.response.record_not_found' ].freeze,
-    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.errors.response.record_not_saved' ].freeze,
-    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.errors.response.record_invalid' ].freeze,
-    ActionController::ParameterMissing => [ :bad_request, 'api.v1.errors.response.parameter_missing' ].freeze,
-    ActionController::RoutingError => [ :not_found, 'api.v1.errors.response.routing_error' ].freeze
+    StandardError => [ :internal_server_error, 'api.v1.response.errors.standard_error' ].freeze,
+    RuntimeError => [ :internal_server_error, 'api.v1.response.errors.runtime_error' ].freeze,
+    ActionController::BadRequest => [ :bad_request, 'api.v1.response.errors.bad_request' ].freeze,
+    ActiveRecord::RecordNotFound => [ :not_found, 'api.v1.response.errors.record_not_found' ].freeze,
+    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.response.errors.record_not_saved' ].freeze,
+    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.response.errors.record_invalid' ].freeze,
+    ActionController::ParameterMissing => [ :bad_request, 'api.v1.response.errors.parameter_missing' ].freeze,
+    ActionController::RoutingError => [ :not_found, 'api.v1.response.errors.routing_error' ].freeze
   }.freeze
 
   def handle_error(exception)

--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -4,8 +4,6 @@ class BaseSerializer
 
   include Alba::Resource
 
-  root_key!
-
   transform_keys :lower_camel, root: true
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,6 @@ module EventRadar
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    config.eager_load_paths << Rails.root.join('lib')
     config.active_job.queue_adapter = :sidekiq
 
     config.active_record.schema_format = :sql

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Rswag::Api.configure do |config|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  # c.openapi_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.join('docs', 'api_guide').to_s
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Rswag::Ui.configure do |config|
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  config.openapi_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
+  config.config_object['showExtensions'] = true
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,20 +30,50 @@
 en:
   api:
     v1:
-      errors:
-        request:
+      info:
+        title: Event Radar - REST API V1
+        description: Full-featured event management JSON REST APIs. Designed to support a standalone, fully functional UI.
+      endpoints:
+        users:
+          index: Paginated list of users for platform administration
+      models:
+        user:
+          id:
+            description: Unique identifier for the user's account
+          email:
+            description: User's email
+          first_name:
+            description: User's first name
+          last_name:
+            description: User's Last name
+          full_name:
+            description: Full name of the user, in 'First Name Last Name' format
+          status:
+            description: User's account status, one of %{statuses}
+          archival_reason:
+            description: Reason for archiving the user's account
+          preferences:
+            theme:
+              description: Preferred theme, one of %{themes}
+          created_at:
+            description: Date and time when the user account was created (ISO8601 format)
+          updated_at:
+            description: Date and time of the last update to the user account (ISO8601 format)
+      response:
+        ok: Success
+        errors:
+          standard_error: Internal server error
+          runtime_error: Internal server error
+          bad_request: Bad request
+          record_not_saved: Unprocessable content - Record not saved
+          record_not_found: Resource not found
+          routing_error: Resource not found
+          record_invalid: Invalid record
+          parameter_missing: Required parameters missing
+      request:
+        errors:
           format:
-            only_json_accepted: 'Only JSON requests are accepted'
-        response:
-          ok: Success
-          standard_error: 'Internal server error'
-          runtime_error: 'Internal server error'
-          bad_request: 'Bad request'
-          record_not_saved: 'Unprocessable content: Record not saved'
-          record_not_found: 'Resource not found'
-          routing_error: 'Resource not found'
-          record_invalid: 'Invalid record'
-          parameter_missing: 'Required parameters missing'
+            only_json_accepted: Only JSON requests are accepted
   activerecord:
     errors:
       models:
@@ -51,6 +81,6 @@ en:
           attributes:
             preferences:
               format:
-                invalid: 'must be a valid JSON object'
+                invalid: must be a valid JSON object
               theme:
                 invalid: 'is not a valid theme. Available options: %{themes}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get 'up' => 'rails/health#show', as: :rails_health_check
@@ -10,7 +8,11 @@ Rails.application.routes.draw do
   # TODO: Add admin constraints
   mount Sidekiq::Web => '/sidekiq'
 
-  namespace :api do
+  # API Documentation
+  mount Rswag::Ui::Engine => 'api-docs'
+  mount Rswag::Api::Engine => 'api-docs'
+
+  namespace :api, defaults: { format: :json } do
     namespace :v1 do
       resources :users, only: [ :index ]
 

--- a/docs/api_guide/v1/swagger.json
+++ b/docs/api_guide/v1/swagger.json
@@ -1,0 +1,121 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Event Radar - REST API V1",
+    "description": "Full-featured event management JSON REST APIs. Designed to support a standalone, fully functional UI.",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/users": {
+      "get": {
+        "summary": "Paginated list of users for platform administration",
+        "tags": ["User"],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/user"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{defaultHost}",
+      "variables": {
+        "defaultHost": {
+          "default": "http://localhost:3000/"
+        }
+      }
+    }
+  ],
+  "components": {
+    "schemas": {
+      "user": {
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "firstName",
+          "lastName",
+          "fullName",
+          "status",
+          "preferences",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minLength": 1,
+            "description": "Unique identifier for the user's account"
+          },
+          "email": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "User's email"
+          },
+          "firstName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "User's first name"
+          },
+          "lastName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "User's Last name"
+          },
+          "fullName": {
+            "type": "string",
+            "minLength": 0,
+            "maxLength": 65535,
+            "description": "Full name of the user, in 'First Name Last Name' format"
+          },
+          "status": {
+            "type": "string",
+            "minLength": 0,
+            "maxLength": 255,
+            "description": "User's account status, one of pending, active, archived"
+          },
+          "archivalReason": {
+            "type": "string",
+            "minLength": 0,
+            "maxLength": 255,
+            "description": "Reason for archiving the user's account"
+          },
+          "preferences": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "theme": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Preferred theme, one of system, dark, light"
+              }
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Date and time when the user account was created (ISO8601 format)"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Date and time of the last update to the user account (ISO8601 format)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/event_radar/config.rb
+++ b/lib/event_radar/config.rb
@@ -3,6 +3,9 @@
 module EventRadar
   class Config
 
+    VARCHAR_MAX_LENGTH = 255
+    TEXT_MAX_LENGTH = 65_535
+
     class << self
 
       def themes

--- a/spec/requests/api/v1/base_controller_spec.rb
+++ b/spec/requests/api/v1/base_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe API::V1::BaseController, type: :request do
 
       it 'responds with HTTP 406 - Not Acceptable' do
         expect(response).to have_http_status(:not_acceptable)
-        expect(json_symbolize[:error][:message]).to eq(I18n.t('api.v1.errors.request.format.only_json_accepted'))
+        expect(json_symbolize[:error][:message]).to eq(I18n.t('api.v1.request.errors.format.only_json_accepted'))
       end
     end
   end

--- a/spec/requests/api/v1/users_controller_sample_request_spec.rb
+++ b/spec/requests/api/v1/users_controller_sample_request_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::UsersController, type: :request do
+  describe '#index' do
+    subject(:get_users) { get api_v1_users_path, headers: { 'Accept' => Mime[:json].to_s } }
+
+    let!(:users) { create_list(:user, collection_size) }
+
+    let(:collection_size) { 4 }
+
+    let(:expected_keys) do
+      [
+        :id,
+        :email,
+        :firstName,
+        :lastName,
+        :fullName,
+        :status,
+        :preferences,
+        :createdAt,
+        :updatedAt
+      ]
+    end
+
+    describe 'response' do
+      before { get_users }
+
+      it 'responds with http success' do
+        expect(response).to be_successful
+      end
+
+      it 'serializes users collection with expected attributes' do
+        users = json_symbolize
+
+        expect(users.size).to eq(collection_size)
+        expect(users.first.keys).to match_array(expected_keys)
+      end
+    end
+
+    context 'when user is archived' do
+      let(:archival_reason) { 'dummy reason' }
+      let!(:archived_user) { create(:user, status: :archived, archival_reason:) }
+
+      it 'includes archival_reason in the serialized output' do
+        get_users
+
+        archived_user_json = json_symbolize.find { |user| user[:id] == archived_user.id }
+
+        expect(archived_user_json[:status]).to eq(archived_user.status)
+        expect(archived_user_json).to have_key(:archivalReason)
+        expect(archived_user_json[:archivalReason]).to eq(archival_reason)
+      end
+    end
+  end
+end

--- a/spec/requests/concerns/error_handler_spec.rb
+++ b/spec/requests/concerns/error_handler_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe 'API Error Handler Concern', type: :request do
     end
 
     it_behaves_like 'error handler', StandardError, :internal_server_error,
-      'api.v1.errors.response.standard_error'
+      'api.v1.response.errors.standard_error'
     it_behaves_like 'error handler', RuntimeError, :internal_server_error,
-      'api.v1.errors.response.runtime_error'
-    it_behaves_like 'error handler', ActionController::BadRequest, :bad_request, 'api.v1.errors.response.bad_request'
-    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.errors.response.record_not_found'
+      'api.v1.response.errors.runtime_error'
+    it_behaves_like 'error handler', ActionController::BadRequest, :bad_request, 'api.v1.response.errors.bad_request'
+    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.response.errors.record_not_found'
     it_behaves_like 'error handler', ActiveRecord::RecordNotSaved, :unprocessable_content,
-      'api.v1.errors.response.record_not_saved'
-    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.errors.response.record_invalid'
+      'api.v1.response.errors.record_not_saved'
+    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.response.errors.record_invalid'
     it_behaves_like 'error handler', ActionController::ParameterMissing.new(:param_name), :bad_request,
-      'api.v1.errors.response.parameter_missing'
+      'api.v1.response.errors.parameter_missing'
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join('docs', 'api_guide').to_s
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.openapi_format = :json
+  config.rswag_dry_run = false
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
+    'v1/swagger.json' => {
+      openapi: '3.0.1',
+      info: {
+        title: I18n.t('api.v1.info.title'),
+        description: I18n.t('api.v1.info.description'),
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'http://localhost:3000/'
+            }
+          }
+        }
+      ],
+      components: {
+        schemas: {
+          user: {
+            type: :object,
+            required: %I[id email firstName lastName fullName status preferences createdAt updatedAt],
+            properties: {
+              id: {
+                type: :integer,
+                minLength: 1,
+                description: I18n.t('api.v1.models.user.id.description')
+              },
+              email: {
+                type: :string,
+                minLength: 1,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.email.description')
+              },
+              firstName: {
+                type: :string,
+                minLength: 1,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.first_name.description')
+              },
+              lastName: {
+                type: :string,
+                minLength: 1,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.last_name.description')
+              },
+              fullName: {
+                type: :string,
+                minLength: 0,
+                maxLength: EventRadar::Config::TEXT_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.full_name.description')
+              },
+              status: {
+                type: :string,
+                minLength: 0,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t(
+                  'api.v1.models.user.status.description',
+                  statuses: User.statuses.keys.join(', ')
+                )
+              },
+              archivalReason: {
+                type: :string,
+                minLength: 0,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.archival_reason.description')
+              },
+              preferences: {
+                type: :object,
+                additionalProperties: false,
+                properties: {
+                  theme: {
+                    type: :string,
+                    minLength: 1,
+                    description: I18n.t(
+                      'api.v1.models.user.preferences.theme.description',
+                      themes: EventRadar::Config.themes.join(', ')
+                    )
+                  }
+                }
+              },
+              createdAt: {
+                type: :string,
+                description: I18n.t('api.v1.models.user.created_at.description')
+              },
+              updatedAt: {
+                type: :string,
+                description: I18n.t('api.v1.models.user.updated_at.description')
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+end


### PR DESCRIPTION
- Add rswag gems
- Install rswag along with RSpec support and Rswag UI
- Export API documentation routes
- Write User#index API specs
- Generate initia OpenAPI documentation
- Improve I18n
- Set JSON as default API format

### TODO

Swagger UI endpoint `http://localhost:3000/api-docs` isn't working
This is auto-generated HTML, no idea where is the issue coming from

<img width="755" alt="image" src="https://github.com/user-attachments/assets/a85833f5-84b6-410d-9b5b-220639005e0d">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Set up rswag for API testing and OpenAPI documentation, including the addition of necessary gems, configuration of routes, and generation of initial API documentation. Enhance API response handling by setting JSON as the default format and improve I18n support. Update tests to include new API specs.

New Features:
- Integrate rswag for API testing and OpenAPI documentation, including the addition of rswag gems and configuration for RSpec support and Rswag UI.
- Export API documentation routes and generate initial OpenAPI documentation for the User#index API.

Enhancements:
- Set JSON as the default format for API responses to ensure consistent data handling.
- Improve internationalization (I18n) by updating the locale files with detailed descriptions for API responses and user model attributes.

Build:
- Add rswag-api, rswag-ui, and rswag-specs gems to the Gemfile for OpenAPI/Swagger support.

Documentation:
- Create a Swagger JSON file to document the API endpoints, providing a detailed schema for the User model and API paths.

Tests:
- Write User#index API specs to validate the new API documentation and ensure correct functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->