### PR TITLE
feat: Setup rswag for API testing and OpenAPI documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
-# Omakase Ruby styling for Rails
 inherit_gem:
+  # Omakase Ruby styling for Rails
   rubocop-rails-omakase: rubocop.yml
+  rswag-specs: .rubocop_rspec_alias_config.yml
 
 require:
   # - rubocop-performance # included in omakase

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem 'strong_migrations'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+# OpenAPI/Swagger
+gem 'rswag-api'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug'
@@ -82,6 +85,8 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec-parameterized'
   gem 'rspec-rails'
+  # Write Request specs with OpenAPI documentation
+  gem 'rswag-specs'
   # Simple one-liner tests for common Rails functionality
   gem 'shoulda-matchers'
   # Test data and mocks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       reline (>= 0.4.2)
     jaro_winkler (1.6.0)
     json (2.7.2)
+    json-schema (4.3.1)
+      addressable (>= 2.8)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -383,6 +385,14 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
+    rswag-api (2.14.0)
+      activesupport (>= 5.2, < 8.0)
+      railties (>= 5.2, < 8.0)
+    rswag-specs (2.14.0)
+      activesupport (>= 5.2, < 8.0)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 5.2, < 8.0)
+      rspec-core (>= 2.14)
     rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -565,6 +575,8 @@ DEPENDENCIES
   rspec
   rspec-parameterized
   rspec-rails
+  rswag-api
+  rswag-specs
   rubocop
   rubocop-factory_bot
   rubocop-performance

--- a/README.md
+++ b/README.md
@@ -144,7 +144,15 @@ on different components and architectural aspects.
 
 ## API Documentation
 
-TODO: Add Swagger/OpenAPI documentation
+[rswag](https://github.com/rswag/rswag) is used to write API specs and auto-generate OpenAPI v3 documentation.
+
+Each time [API specs](./spec/requests/api) are updated or created, refresh API documentation using
+
+```bash
+RAILS_ENV=test RSWAG_DRY_RUN=0 rails rswag PATTERN="spec/requests/api/**/*_spec.rb"
+```
+
+[API documentation](./docs/api_guide) is generated docs folder.
 
 ## User documentation
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -19,7 +19,7 @@ module API
 
       def ensure_json_request_format
         unless request.format.json?
-          respond_with_error(status: :not_acceptable, i18n_key: 'api.v1.errors.request.format.only_json_accepted')
+          respond_with_error(status: :not_acceptable, i18n_key: 'api.v1.request.errors.format.only_json_accepted')
         end
       end
 

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -15,14 +15,14 @@ module ErrorHandler
   private
 
   ERROR_MAPPINGS = {
-    StandardError => [ :internal_server_error, 'api.v1.errors.response.standard_error' ].freeze,
-    RuntimeError => [ :internal_server_error, 'api.v1.errors.response.runtime_error' ].freeze,
-    ActionController::BadRequest => [ :bad_request, 'api.v1.errors.response.bad_request' ].freeze,
-    ActiveRecord::RecordNotFound => [ :not_found, 'api.v1.errors.response.record_not_found' ].freeze,
-    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.errors.response.record_not_saved' ].freeze,
-    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.errors.response.record_invalid' ].freeze,
-    ActionController::ParameterMissing => [ :bad_request, 'api.v1.errors.response.parameter_missing' ].freeze,
-    ActionController::RoutingError => [ :not_found, 'api.v1.errors.response.routing_error' ].freeze
+    StandardError => [ :internal_server_error, 'api.v1.response.errors.standard_error' ].freeze,
+    RuntimeError => [ :internal_server_error, 'api.v1.response.errors.runtime_error' ].freeze,
+    ActionController::BadRequest => [ :bad_request, 'api.v1.response.errors.bad_request' ].freeze,
+    ActiveRecord::RecordNotFound => [ :not_found, 'api.v1.response.errors.record_not_found' ].freeze,
+    ActiveRecord::RecordNotSaved => [ :unprocessable_content, 'api.v1.response.errors.record_not_saved' ].freeze,
+    ActiveRecord::RecordInvalid => [ :bad_request, 'api.v1.response.errors.record_invalid' ].freeze,
+    ActionController::ParameterMissing => [ :bad_request, 'api.v1.response.errors.parameter_missing' ].freeze,
+    ActionController::RoutingError => [ :not_found, 'api.v1.response.errors.routing_error' ].freeze
   }.freeze
 
   def handle_error(exception)

--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -4,8 +4,6 @@ class BaseSerializer
 
   include Alba::Resource
 
-  root_key!
-
   transform_keys :lower_camel, root: true
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,6 @@ module EventRadar
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    config.eager_load_paths << Rails.root.join('lib')
     config.active_job.queue_adapter = :sidekiq
 
     config.active_record.schema_format = :sql

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Rswag::Api.configure do |config|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  # c.openapi_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.join('docs', 'api_guide').to_s
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,20 +30,50 @@
 en:
   api:
     v1:
-      errors:
-        request:
+      info:
+        title: Event Radar - REST API V1
+        description: Full-featured event management JSON REST APIs. Designed to support a standalone, fully functional UI.
+      endpoints:
+        users:
+          index: Paginated list of users for platform administration
+      models:
+        user:
+          id:
+            description: Unique identifier for the user's account
+          email:
+            description: User's email
+          first_name:
+            description: User's first name
+          last_name:
+            description: User's Last name
+          full_name:
+            description: Full name of the user, in 'First Name Last Name' format
+          status:
+            description: User's account status, one of %{statuses}
+          archival_reason:
+            description: Reason for archiving the user's account
+          preferences:
+            theme:
+              description: Preferred theme, one of %{themes}
+          created_at:
+            description: Date and time when the user account was created (ISO8601 format)
+          updated_at:
+            description: Date and time of the last update to the user account (ISO8601 format)
+      response:
+        ok: Success
+        errors:
+          standard_error: Internal server error
+          runtime_error: Internal server error
+          bad_request: Bad request
+          record_not_saved: Unprocessable content - Record not saved
+          record_not_found: Resource not found
+          routing_error: Resource not found
+          record_invalid: Invalid record
+          parameter_missing: Required parameters missing
+      request:
+        errors:
           format:
-            only_json_accepted: 'Only JSON requests are accepted'
-        response:
-          ok: Success
-          standard_error: 'Internal server error'
-          runtime_error: 'Internal server error'
-          bad_request: 'Bad request'
-          record_not_saved: 'Unprocessable content: Record not saved'
-          record_not_found: 'Resource not found'
-          routing_error: 'Resource not found'
-          record_invalid: 'Invalid record'
-          parameter_missing: 'Required parameters missing'
+            only_json_accepted: Only JSON requests are accepted
   activerecord:
     errors:
       models:
@@ -51,6 +81,6 @@ en:
           attributes:
             preferences:
               format:
-                invalid: 'must be a valid JSON object'
+                invalid: must be a valid JSON object
               theme:
                 invalid: 'is not a valid theme. Available options: %{themes}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get 'up' => 'rails/health#show', as: :rails_health_check
 
   # TODO: Add admin constraints
   mount Sidekiq::Web => '/sidekiq'
+  mount Rswag::Api::Engine => 'docs/api'
 
-  namespace :api do
+  namespace :api, defaults: { format: :json } do
     namespace :v1 do
       resources :users, only: [ :index ]
 

--- a/docs/api_guide/v1/open_api.yaml
+++ b/docs/api_guide/v1/open_api.yaml
@@ -1,0 +1,114 @@
+---
+openapi: 3.0.3
+info:
+  title: Event Radar - REST API V1
+  description: Full-featured event management JSON REST APIs. Designed to support
+    a standalone, fully functional UI.
+  version: v1
+paths:
+  '/api/v1/users':
+    get:
+      summary: Paginated list of users for platform administration
+      tags:
+        - User
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              example:
+                - id: 1
+                  email: john@smith.example
+                  firstName: John
+                  lastName: Smith
+                  fullName: John Smith
+                  status: active
+                  preferences:
+                    theme: system
+                  createdAt: '2024-09-25T10:00:25Z'
+                  updatedAt: '2024-09-26T06:12:31Z'
+                - id: 2
+                  email: bruce@wayne.batman
+                  firstName: Bruce
+                  lastName: Wayne
+                  fullName: Bruce Wayne
+                  status: archived
+                  archivalReason: Some reason for account archival
+                  preferences:
+                    theme: dark
+                  createdAt: '2024-09-26T01:20:00Z'
+                  updatedAt: '2024-09-26T06:30:30Z'
+              schema:
+                type: array
+                items:
+                  '$ref': '#/components/schemas/user'
+servers:
+  - url: https://{defaultHost}
+    variables:
+      defaultHost:
+        default: www.example.com
+components:
+  schemas:
+    user:
+      type: object
+      required:
+        - id
+        - email
+        - firstName
+        - lastName
+        - fullName
+        - status
+        - preferences
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: integer
+          minLength: 1
+          description: Unique identifier for the user's account
+        email:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: User's email
+        firstName:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: User's first name
+        lastName:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: User's Last name
+        fullName:
+          type: string
+          minLength: 0
+          maxLength: 65535
+          description: Full name of the user, in 'First Name Last Name' format
+        status:
+          type: string
+          minLength: 0
+          maxLength: 255
+          description: User's account status, one of pending, active, archived
+        archivalReason:
+          type: string
+          nullable: true
+          minLength: 0
+          maxLength: 255
+          description: Reason for archiving the user's account
+        preferences:
+          type: object
+          additionalProperties: false
+          properties:
+            theme:
+              type: string
+              minLength: 1
+              description: Preferred theme, one of system, dark, light
+        createdAt:
+          type: string
+          description: Date and time when the user account was created (ISO8601 format)
+        updatedAt:
+          type: string
+          description: Date and time of the last update to the user account (ISO8601
+            format)

--- a/lib/event_radar/config.rb
+++ b/lib/event_radar/config.rb
@@ -3,6 +3,9 @@
 module EventRadar
   class Config
 
+    VARCHAR_MAX_LENGTH = 255
+    TEXT_MAX_LENGTH = 65_535
+
     class << self
 
       def themes

--- a/spec/requests/api/v1/base_controller_spec.rb
+++ b/spec/requests/api/v1/base_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe API::V1::BaseController, type: :request do
 
       it 'responds with HTTP 406 - Not Acceptable' do
         expect(response).to have_http_status(:not_acceptable)
-        expect(json_symbolize[:error][:message]).to eq(I18n.t('api.v1.errors.request.format.only_json_accepted'))
+        expect(json_symbolize[:error][:message]).to eq(I18n.t('api.v1.request.errors.format.only_json_accepted'))
       end
     end
   end

--- a/spec/requests/api/v1/users_controller_sample_request_spec.rb
+++ b/spec/requests/api/v1/users_controller_sample_request_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Intentionally kept as an example
+# API specs should be written with Rswag, see 'spec/requests/api/v1/users_controller_spec.rb'
+RSpec.describe API::V1::UsersController, type: :request do
+  describe '#index' do
+    subject(:get_users) { get api_v1_users_path }
+
+    let!(:users) { create_list(:user, collection_size) }
+
+    let(:collection_size) { 4 }
+
+    let(:expected_keys) do
+      [
+        :id,
+        :email,
+        :firstName,
+        :lastName,
+        :fullName,
+        :status,
+        :preferences,
+        :createdAt,
+        :updatedAt
+      ]
+    end
+
+    describe 'response' do
+      before { get_users }
+
+      it 'responds with http success' do
+        expect(response).to be_successful
+      end
+
+      it 'serializes users collection with expected attributes' do
+        users = json_symbolize
+
+        expect(users.size).to eq(collection_size)
+        expect(users.first.keys).to match_array(expected_keys)
+      end
+    end
+
+    context 'when user is archived' do
+      let(:archival_reason) { 'dummy reason' }
+      let!(:archived_user) { create(:user, status: :archived, archival_reason:) }
+
+      it 'includes archival_reason in the serialized output' do
+        get_users
+
+        archived_user_json = json_symbolize.find { |user| user[:id] == archived_user.id }
+
+        expect(archived_user_json[:status]).to eq(archived_user.status)
+        expect(archived_user_json).to have_key(:archivalReason)
+        expect(archived_user_json[:archivalReason]).to eq(archival_reason)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -1,59 +1,63 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'swagger_helper'
 
 RSpec.describe API::V1::UsersController, type: :request do
-  describe '#index' do
-    subject(:get_users) { get api_v1_users_path, headers: { 'Accept' => Mime[:json].to_s } }
+  path '/api/v1/users' do
+    let!(:users) { create_list(:user, 2) }
+    let(:expected_result) { JSON.parse(API::V1::UserSerializer.new(users).serialize) }
 
-    let!(:users) { create_list(:user, collection_size) }
+    get I18n.t('api.v1.endpoints.users.index') do
+      produces Mime[:json].to_s
 
-    let(:collection_size) { 4 }
-    let(:root_key) { :users }
+      tags User.to_s
 
-    let(:expected_keys) do
-      [
-        :id,
-        :email,
-        :firstName,
-        :lastName,
-        :fullName,
-        :status,
-        :preferences,
-        :createdAt,
-        :updatedAt
-      ]
-    end
+      response 200, I18n.t('api.v1.response.ok') do
+        after do |example|
+          content = example.metadata[:response][:content] || {}
 
-    describe 'response' do
-      before { get_users }
+          example_spec = {
+            Mime[:json].to_s => {
+              example: [
+                {
+                  id: 1,
+                  email: "john@smith.example",
+                  firstName: "John",
+                  lastName: "Smith",
+                  fullName: "John Smith",
+                  status: "active",
+                  preferences: {
+                    theme: 'system'
+                  },
+                  createdAt: "2024-09-25T10:00:25Z",
+                  updatedAt: "2024-09-26T06:12:31Z"
+                },
+                {
+                  id: 2,
+                  email: "bruce@wayne.batman",
+                  firstName: "Bruce",
+                  lastName: "Wayne",
+                  fullName: "Bruce Wayne",
+                  status: "archived",
+                  archivalReason: 'Some reason for account archival',
+                  preferences: {
+                    theme: 'dark'
+                  },
+                  createdAt: "2024-09-26T01:20:00Z",
+                  updatedAt: "2024-09-26T06:30:30Z"
+                }
+              ]
+            }
+          }
 
-      it 'responds with http success' do
-        expect(response).to be_successful
-      end
+          example.metadata[:response][:content] = content.deep_merge(example_spec)
+        end
 
-      it 'serializes users collection with expected attributes' do
-        expect(json_symbolize).to have_key(root_key)
+        schema type: :array, items: { '$ref' => '#/components/schemas/user' }
 
-        users = json_symbolize[root_key]
-
-        expect(users.size).to eq(collection_size)
-        expect(users.first.keys).to match_array(expected_keys)
-      end
-    end
-
-    context 'when user is archived' do
-      let(:archival_reason) { 'dummy reason' }
-      let!(:archived_user) { create(:user, status: :archived, archival_reason:) }
-
-      it 'includes archival_reason in the serialized output' do
-        get_users
-
-        archived_user_json = json_symbolize[root_key].find { |user| user[:id] == archived_user.id }
-
-        expect(archived_user_json[:status]).to eq(archived_user.status)
-        expect(archived_user_json).to have_key(:archivalReason)
-        expect(archived_user_json[:archivalReason]).to eq(archival_reason)
+        run_test! do |_response|
+          expect(json).to eq(expected_result)
+        end
       end
     end
   end

--- a/spec/requests/concerns/error_handler_spec.rb
+++ b/spec/requests/concerns/error_handler_spec.rb
@@ -30,11 +30,9 @@ RSpec.describe 'API Error Handler Concern', type: :request do
   describe 'Error handlers' do
     shared_examples 'error handler' do |error_class, status, message_key|
       before do
-        headers = { 'Accept' => Mime[:json].to_s }
-
         allow_any_instance_of(API::V1::TestController).to receive(:index).and_raise(error_class)
 
-        get '/api/v1/test', headers: headers
+        get '/api/v1/test'
       end
 
       it "handles #{error_class} correctly" do
@@ -48,15 +46,15 @@ RSpec.describe 'API Error Handler Concern', type: :request do
     end
 
     it_behaves_like 'error handler', StandardError, :internal_server_error,
-      'api.v1.errors.response.standard_error'
+      'api.v1.response.errors.standard_error'
     it_behaves_like 'error handler', RuntimeError, :internal_server_error,
-      'api.v1.errors.response.runtime_error'
-    it_behaves_like 'error handler', ActionController::BadRequest, :bad_request, 'api.v1.errors.response.bad_request'
-    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.errors.response.record_not_found'
+      'api.v1.response.errors.runtime_error'
+    it_behaves_like 'error handler', ActionController::BadRequest, :bad_request, 'api.v1.response.errors.bad_request'
+    it_behaves_like 'error handler', ActiveRecord::RecordNotFound, :not_found, 'api.v1.response.errors.record_not_found'
     it_behaves_like 'error handler', ActiveRecord::RecordNotSaved, :unprocessable_content,
-      'api.v1.errors.response.record_not_saved'
-    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.errors.response.record_invalid'
+      'api.v1.response.errors.record_not_saved'
+    it_behaves_like 'error handler', ActiveRecord::RecordInvalid, :bad_request, 'api.v1.response.errors.record_invalid'
     it_behaves_like 'error handler', ActionController::ParameterMissing.new(:param_name), :bad_request,
-      'api.v1.errors.response.parameter_missing'
+      'api.v1.response.errors.parameter_missing'
   end
 end

--- a/spec/requests/concerns/versionable_spec.rb
+++ b/spec/requests/concerns/versionable_spec.rb
@@ -31,11 +31,9 @@ RSpec.describe "API Versionable Concern", type: :request do
     Rails.application.reload_routes!
   end
 
-  let(:headers) {  { 'Accept' => Mime[:json].to_s } }
-
   context 'when valid version' do
     it 'returns success' do
-      get '/api/v1/test_versionable', headers: headers
+      get '/api/v1/test_versionable'
 
       expect(response).to have_http_status(:success)
       expect(json_symbolize[:message]).to eq("API version is v1")
@@ -45,7 +43,7 @@ RSpec.describe "API Versionable Concern", type: :request do
   context 'when invalid version' do
     it 'returns API version mismatch error' do
       expect {
-        get '/api/v2/test_versionable', headers: headers
+        get '/api/v2/test_versionable'
       }.to raise_error(Versionable::APIVersionMismatchError)
     end
   end

--- a/spec/requests/rack/attack_spec.rb
+++ b/spec/requests/rack/attack_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe Rack::Attack do
     described_class.cache.store = cache_store_was
   end
 
+  let(:headers) { { 'ACCEPT' => Mime[:json].to_s } }
+
   it 'throttles request' do
-    headers = { 'ACCEPT' => 'application/json' }
     stub_const('Rack::Attack::LIMIT_PER_IP', 2)
 
     get('/up', headers:)

--- a/spec/serializers/api/v1/user_serializer_spec.rb
+++ b/spec/serializers/api/v1/user_serializer_spec.rb
@@ -9,17 +9,15 @@ RSpec.describe API::V1::UserSerializer, type: :serializer do
 
   let(:expected_user_data) do
     {
-      "user" => {
-        "id" => user.id,
-        "firstName" => user.first_name,
-        "lastName" => user.last_name,
-        "fullName" => user.full_name,
-        "email" => user.email,
-        "status" => user.status,
-        "preferences" => { "theme" => "dark" },
-        "createdAt" => user.created_at.iso8601,
-        "updatedAt" => user.updated_at.iso8601
-      }
+      "id" => user.id,
+      "firstName" => user.first_name,
+      "lastName" => user.last_name,
+      "fullName" => user.full_name,
+      "email" => user.email,
+      "status" => user.status,
+      "preferences" => { "theme" => "dark" },
+      "createdAt" => user.created_at.iso8601,
+      "updatedAt" => user.updated_at.iso8601
     }
   end
 

--- a/spec/support/json_helper.rb
+++ b/spec/support/json_helper.rb
@@ -19,11 +19,15 @@ module JsonHelper
   end
 
   def json_symbolize
-    @json_symbolize ||= json.deep_symbolize_keys
-  end
-
-  def json_with_indifferent_access
-    @json_with_indifferent_access ||= json.with_indifferent_access
+    @json_symbolize ||= begin
+      if json.is_a?(Hash)
+        json.deep_symbolize_keys
+      elsif json.is_a?(Array)
+        json.map { |item| item.is_a?(Hash) ? item.deep_symbolize_keys : item }
+      else
+        json
+      end
+    end
   end
 
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join('docs', 'api_guide').to_s
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.openapi_format = :yaml
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
+    'v1/open_api.yaml' => {
+      openapi: '3.0.3',
+      info: {
+        title: I18n.t('api.v1.info.title'),
+        description: I18n.t('api.v1.info.description'),
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ],
+      components: {
+        schemas: {
+          user: {
+            type: :object,
+            required: %I[id email firstName lastName fullName status preferences createdAt updatedAt],
+            properties: {
+              id: {
+                type: :integer,
+                minLength: 1,
+                description: I18n.t('api.v1.models.user.id.description')
+              },
+              email: {
+                type: :string,
+                minLength: 1,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.email.description')
+              },
+              firstName: {
+                type: :string,
+                minLength: 1,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.first_name.description')
+              },
+              lastName: {
+                type: :string,
+                minLength: 1,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.last_name.description')
+              },
+              fullName: {
+                type: :string,
+                minLength: 0,
+                maxLength: EventRadar::Config::TEXT_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.full_name.description')
+              },
+              status: {
+                type: :string,
+                minLength: 0,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t(
+                  'api.v1.models.user.status.description',
+                  statuses: User.statuses.keys.join(', ')
+                )
+              },
+              archivalReason: {
+                type: :string,
+                nullable: true,
+                minLength: 0,
+                maxLength: EventRadar::Config::VARCHAR_MAX_LENGTH,
+                description: I18n.t('api.v1.models.user.archival_reason.description')
+              },
+              preferences: {
+                type: :object,
+                additionalProperties: false,
+                properties: {
+                  theme: {
+                    type: :string,
+                    minLength: 1,
+                    description: I18n.t(
+                      'api.v1.models.user.preferences.theme.description',
+                      themes: EventRadar::Config.themes.join(', ')
+                    )
+                  }
+                }
+              },
+              createdAt: {
+                type: :string,
+                description: I18n.t('api.v1.models.user.created_at.description')
+              },
+              updatedAt: {
+                type: :string,
+                description: I18n.t('api.v1.models.user.updated_at.description')
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+end


### PR DESCRIPTION
New Features:
- Integrate rswag for API testing and OpenAPI documentation generation, enabling automated API documentation updates based on RSpec tests

Enhancements:
- Set JSON as the default format for API responses to ensure consistent data handling across endpoints
- Improve internationalization (I18n) by adding detailed descriptions for API models and responses in the locale files

Documentation:
- Add initial OpenAPI documentation for the 'User#index' endpoint, providing a structured overview of the API's capabilities and expected responses
- Update README to include instructions on using rswag for generating and updating API documentation

Tests:
- Add 'User#index' API specs to validate the functionality and ensure compliance with the documented API behavior

Todo:
- Test and document API errors 'User#index'
- Abstract repeating logic from Rswag API specs to be shared across specs