### PR TITLE
test: Add time range validations for start and end times in events related models

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,8 +25,8 @@ class Event < ApplicationRecord
   has_many :offline_meetings, dependent: :destroy, inverse_of: :event
 
   validates :title, :start_time, presence: true
-  # TODO: If end_time is present, ensure it is later than start_time
-  # TODO: Validate start and end time to be in future and be valid date
+  validates :end_time, allow_nil: true, time_range: true
+  validates :start_time, time_range: true
 
   # TODO: Add helper methods to determine online?, offline? or hybrid? events
 

--- a/app/models/offline_meeting.rb
+++ b/app/models/offline_meeting.rb
@@ -28,6 +28,7 @@ class OfflineMeeting < ApplicationRecord
   belongs_to :event, inverse_of: :offline_meetings
 
   validates :title, :start_time, presence: true
-  # TODO: If end_time is present, ensure it is later than start_time
+  validates :end_time, allow_nil: true, time_range: true
+  validates :start_time, time_range: true
 
 end

--- a/app/models/online_meeting.rb
+++ b/app/models/online_meeting.rb
@@ -28,6 +28,7 @@ class OnlineMeeting < ApplicationRecord
   belongs_to :event, inverse_of: :online_meetings
 
   validates :title, :start_time, presence: true
-  # TODO: If end_time is present, ensure it is later than start_time
+  validates :end_time, allow_nil: true, time_range: true
+  validates :start_time, time_range: true
 
 end

--- a/app/validators/time_range_validator.rb
+++ b/app/validators/time_range_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class TimeRangeValidator < ActiveModel::EachValidator
+
+  def validate_each(record, attribute, _value)
+    start_time = record.start_time
+    end_time = record.end_time
+
+    return unless start_time && end_time
+
+    time_invalid = start_time >= end_time
+
+    record.errors.add(attribute, :invalid_time_range) if time_invalid
+  end
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,4 +93,22 @@ en:
         event_organizer:
           attributes:
             user:
-              taken: 'event is already assigned to this user'
+              taken: event is already assigned to this user
+        event:
+          attributes:
+            start_time:
+              invalid_time_range: must be before the end time
+            end_time:
+              invalid_time_range: must be after the start time
+        online_meeting:
+          attributes:
+            start_time:
+              invalid_time_range: must be before the end time
+            end_time:
+              invalid_time_range: must be after the start time
+        offline_meeting:
+          attributes:
+            start_time:
+              invalid_time_range: must be before the end time
+            end_time:
+              invalid_time_range: must be after the start time

--- a/spec/factories/event_time_range_traits.rb
+++ b/spec/factories/event_time_range_traits.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Conveniently abstracted shared time range traits to be used in event, online and offline meeting models
+FactoryBot.define do
+  trait :future do
+    start_time { Faker::Time.between(from: DateTime.now + 1.day, to: DateTime.now + 5.days, format: :default) }
+    end_time { Faker::Time.between(from: DateTime.now + 5.days, to: DateTime.now + 10.days, format: :default) }
+  end
+
+  trait :past do
+    start_time { Faker::Time.between(from: DateTime.now - 10.days, to: DateTime.now - 5.days, format: :default) }
+    end_time { Faker::Time.between(from: DateTime.now - 5.days, to: DateTime.now - 1.day, format: :default) }
+  end
+
+  trait :ongoing do
+    start_time { Faker::Time.between(from: DateTime.now - 1.day, to: DateTime.now, format: :default) }
+    end_time { Faker::Time.between(from: DateTime.now + 1.hour, to: DateTime.now + 2.days, format: :default) }
+  end
+
+  trait :open_ended do
+    end_time { nil }
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -21,25 +21,11 @@ FactoryBot.define do
     title { "event-#{Faker::Lorem.sentence(word_count: 3)}" }
     description { Faker::Lorem.paragraph }
 
-    start_time { Faker::Time.between(from: DateTime.now + 1.day, to: DateTime.now + 5.days, format: :default) }
-
-    trait :future do
-      end_time { Faker::Time.between(from: DateTime.now + 5.days, to: DateTime.now + 10.days, format: :default) }
-    end
-
-    trait :past do
-      start_time { Faker::Time.between(from: DateTime.now - 10.days, to: DateTime.now - 5.days, format: :default) }
-      end_time { Faker::Time.between(from: DateTime.now - 5.days, to: DateTime.now - 1.day, format: :default) }
-    end
-
-    trait :ongoing do
-      start_time { Faker::Time.between(from: DateTime.now - 1.day, to: DateTime.now, format: :default) }
-      end_time { Faker::Time.between(from: DateTime.now + 1.hour, to: DateTime.now + 2.days, format: :default) }
-    end
-
-    trait :open_ended do
-      end_time { nil }
-    end
+    # Shared time range traits from 'event_time_range_traits.rb'
+    future
+    past
+    ongoing
+    open_ended
 
     trait :with_online_meeting do
       after(:create) do |event|

--- a/spec/factories/offline_meetings.rb
+++ b/spec/factories/offline_meetings.rb
@@ -24,26 +24,13 @@
 FactoryBot.define do
   factory :offline_meeting, traits: [ :future ] do
     title { "offline-meeting-#{Faker::Lorem.sentence(word_count: 3)}" }
-    start_time { Faker::Time.between(from: DateTime.now + 1.day, to: DateTime.now + 5.days, format: :default) }
 
     association :event
 
-    trait :future do
-      end_time { Faker::Time.between(from: DateTime.now + 5.days, to: DateTime.now + 10.days, format: :default) }
-    end
-
-    trait :past do
-      start_time { Faker::Time.between(from: DateTime.now - 10.days, to: DateTime.now - 5.days, format: :default) }
-      end_time { Faker::Time.between(from: DateTime.now - 5.days, to: DateTime.now - 1.day, format: :default) }
-    end
-
-    trait :ongoing do
-      start_time { Faker::Time.between(from: DateTime.now - 1.day, to: DateTime.now, format: :default) }
-      end_time { Faker::Time.between(from: DateTime.now + 1.hour, to: DateTime.now + 2.days, format: :default) }
-    end
-
-    trait :open_ended do
-      end_time { nil }
-    end
+    # Shared time range traits from 'event_time_range_traits.rb'
+    future
+    past
+    ongoing
+    open_ended
   end
 end

--- a/spec/factories/online_meetings.rb
+++ b/spec/factories/online_meetings.rb
@@ -27,24 +27,10 @@ FactoryBot.define do
 
     association :event
 
-    start_time { Faker::Time.between(from: DateTime.now + 1.day, to: DateTime.now + 5.days, format: :default) }
-
-    trait :future do
-      end_time { Faker::Time.between(from: DateTime.now + 5.days, to: DateTime.now + 10.days, format: :default) }
-    end
-
-    trait :past do
-      start_time { Faker::Time.between(from: DateTime.now - 10.days, to: DateTime.now - 5.days, format: :default) }
-      end_time { Faker::Time.between(from: DateTime.now - 5.days, to: DateTime.now - 1.day, format: :default) }
-    end
-
-    trait :ongoing do
-      start_time { Faker::Time.between(from: DateTime.now - 1.day, to: DateTime.now, format: :default) }
-      end_time { Faker::Time.between(from: DateTime.now + 1.hour, to: DateTime.now + 2.days, format: :default) }
-    end
-
-    trait :open_ended do
-      end_time { nil }
-    end
+    # Shared time range traits from 'event_time_range_traits.rb'
+    future
+    past
+    ongoing
+    open_ended
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -25,18 +25,7 @@ RSpec.describe Event, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
-    context 'when nil end_time (open ended)' do
-      let(:open_ended_event) { build(:event, :open_ended) }
-
-      it 'is expected to be valid' do
-        expect(open_ended_event).to be_valid
-      end
-    end
-
-    context 'when end_time is earlier than start_time' do
-      xit 'is expected to be invalid' do
-      end
-    end
+    include_examples 'time_range_validations'
   end
 
   describe '#associations' do

--- a/spec/models/offline_meeting_spec.rb
+++ b/spec/models/offline_meeting_spec.rb
@@ -30,18 +30,7 @@ RSpec.describe OfflineMeeting, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
-    context 'when nil end_time (open ended)' do
-      let(:open_ended_meeting) { build(:offline_meeting, :open_ended) }
-
-      it 'is expected to be valid' do
-        expect(open_ended_meeting).to be_valid
-      end
-    end
-
-    context 'when end_time is earlier than start_time' do
-      xit 'is expected to be invalid' do
-      end
-    end
+    include_examples 'time_range_validations'
   end
 
   describe '#associations' do

--- a/spec/models/online_meeting_spec.rb
+++ b/spec/models/online_meeting_spec.rb
@@ -30,18 +30,7 @@ RSpec.describe OnlineMeeting, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
-    context 'when nil end_time (open ended)' do
-      let(:open_ended_meeting) { build(:online_meeting, :open_ended) }
-
-      it 'is expected to be valid' do
-        expect(open_ended_meeting).to be_valid
-      end
-    end
-
-    context 'when end_time is earlier than start_time' do
-      xit 'is expected to be invalid' do
-      end
-    end
+    include_examples 'time_range_validations'
   end
 
   describe '#associations' do

--- a/spec/support/shared_examples/time_range_validations.rb
+++ b/spec/support/shared_examples/time_range_validations.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# spec/support/shared_examples/time_range_validations.rb
+
+RSpec.shared_examples 'time_range_validations' do
+  let(:model_name) { described_class.to_s.underscore }
+
+  describe 'time range validations' do
+    context 'when nil end_time (open ended)' do
+      let(:open_ended_meeting) { build(model_name.to_sym, :open_ended) }
+
+      it 'is expected to be valid' do
+        expect(open_ended_meeting).to be_valid
+      end
+    end
+
+    context 'when start_time is earlier than end_time' do
+      let(:valid_meeting) { build(model_name.to_sym, start_time: Time.current, end_time: 1.hour.from_now) }
+
+      it 'is expected to be valid' do
+        expect(valid_meeting).to be_valid
+      end
+    end
+
+    context 'when end_time is earlier than start_time' do
+      let(:invalid_meeting) { build(model_name.to_sym, start_time: Time.current, end_time: 1.hour.ago) }
+
+      it 'is expected to be invalid' do
+        expect(invalid_meeting).not_to be_valid
+        expect(invalid_meeting.errors[:start_time])
+          .to include(I18n.t("activerecord.errors.models.#{model_name}.attributes.start_time.invalid_time_range"))
+        expect(invalid_meeting.errors[:end_time])
+          .to include(I18n.t("activerecord.errors.models.#{model_name}.attributes.end_time.invalid_time_range"))
+      end
+    end
+
+    context 'when start_time and end_time are equal' do
+      let(:current_time) { Time.current }
+      let(:equal_time_meeting) { build(model_name.to_sym, start_time: current_time, end_time: current_time) }
+
+      it 'is expected to be invalid' do
+        expect(equal_time_meeting).not_to be_valid
+        expect(equal_time_meeting.errors[:start_time])
+          .to include(I18n.t("activerecord.errors.models.#{model_name}.attributes.start_time.invalid_time_range"))
+        expect(equal_time_meeting.errors[:end_time])
+          .to include(I18n.t("activerecord.errors.models.#{model_name}.attributes.end_time.invalid_time_range"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tests:
- Add shared examples for time range validations to streamline testing across different models

Enhancements:
- Abstract shared time range traits into a separate file for reuse across event, online, and offline meeting models
- Implement a custom `TimeRangeValidator` to ensure start and end times are valid across models

I18n:
- Add validation error messages for invalid time ranges in the English locale configuration (I18n)

