### PR TITLE
feat: Add status to Event models

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@
 #  description :text             not null
 #  end_time    :datetime
 #  start_time  :datetime         not null
+#  status      :integer          default(0), not null
 #  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -18,12 +19,17 @@
 #
 class Event < ApplicationRecord
 
+  # Associations
   has_many :event_organizers, inverse_of: :event
   has_many :organizers, through: :event_organizers, source: :user, inverse_of: :organized_events
 
   has_many :online_meetings, dependent: :destroy, inverse_of: :event
   has_many :offline_meetings, dependent: :destroy, inverse_of: :event
 
+  # Enums
+  enum status: { draft: 0, published: 1, cancelled: 2, archived: 3  }
+
+  # Validations
   validates :title, :start_time, presence: true
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true

--- a/app/models/event_organizer.rb
+++ b/app/models/event_organizer.rb
@@ -13,8 +13,8 @@
 # Indexes
 #
 #  index_event_organizers_on_event_id              (event_id)
-#  index_event_organizers_on_event_id_and_user_id  (event_id,user_id) UNIQUE
 #  index_event_organizers_on_user_id               (user_id)
+#  index_event_organizers_on_user_id_and_event_id  (user_id,event_id) UNIQUE
 #
 # Foreign Keys
 #
@@ -23,9 +23,11 @@
 #
 class EventOrganizer < ApplicationRecord
 
+  # Associations
   belongs_to :event, inverse_of: :event_organizers
   belongs_to :user, inverse_of: :event_organizers
 
+  # Validations
   validates :user, uniqueness: { scope: :event }
 
   # TODO: Ensure only active users can be assigned to an event

--- a/app/models/offline_meeting.rb
+++ b/app/models/offline_meeting.rb
@@ -7,6 +7,7 @@
 #  id         :bigint           not null, primary key
 #  end_time   :datetime
 #  start_time :datetime         not null
+#  status     :integer          default(0), not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -25,8 +26,13 @@ class OfflineMeeting < ApplicationRecord
 
   # TODO: Add support for physical address, it should be validated with maps API
 
+  # Associations
   belongs_to :event, inverse_of: :offline_meetings
 
+  # Enums
+  enum status: { draft: 0, published: 1, cancelled: 2, archived: 3  }
+
+  # Validations
   validates :title, :start_time, presence: true
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true

--- a/app/models/online_meeting.rb
+++ b/app/models/online_meeting.rb
@@ -7,6 +7,7 @@
 #  id         :bigint           not null, primary key
 #  end_time   :datetime
 #  start_time :datetime         not null
+#  status     :integer          default(0), not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -25,8 +26,13 @@ class OnlineMeeting < ApplicationRecord
 
   # TODO: Add support for setting up online meeting using services like Zoom, Google meet and Microsoft teams
 
+  # Associations
   belongs_to :event, inverse_of: :online_meetings
 
+  # Enums
+  enum status: { draft: 0, published: 1, cancelled: 2, archived: 3  }
+
+  # Validations
   validates :title, :start_time, presence: true
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,9 +27,14 @@ class User < ApplicationRecord
   after_initialize :set_default_preferences, if: :new_record?
   before_save :sanitize_names
 
+  # Associations
   has_many :event_organizers, inverse_of: :user
   has_many :organized_events, through: :event_organizers, source: :event, inverse_of: :organizers
 
+  # Enums
+  enum :status, { pending: 0, active: 1, archived: 2 }
+
+  # Validations
   validates :first_name, presence: true
   validates :last_name, presence: true
 
@@ -41,8 +46,6 @@ class User < ApplicationRecord
   validates :preferences, preferences: true
 
   validates :archival_reason, presence: true, if: :archived?
-
-  enum :status, { pending: 0, active: 1, archived: 2 }
 
   private
 

--- a/db/migrate/20241002173107_add_status_to_events.rb
+++ b/db/migrate/20241002173107_add_status_to_events.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusToEvents < ActiveRecord::Migration[7.2]
+
+  def change
+    add_column :events, :status, :integer, limit: 2, default: 0, null: false
+  end
+
+end

--- a/db/migrate/20241002173252_add_status_to_online_meetings.rb
+++ b/db/migrate/20241002173252_add_status_to_online_meetings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusToOnlineMeetings < ActiveRecord::Migration[7.2]
+
+  def change
+    add_column :online_meetings, :status, :integer, limit: 2, default: 0, null: false
+  end
+
+end

--- a/db/migrate/20241002173300_add_status_to_offline_meetings.rb
+++ b/db/migrate/20241002173300_add_status_to_offline_meetings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusToOfflineMeetings < ActiveRecord::Migration[7.2]
+
+  def change
+    add_column :offline_meetings, :status, :integer, limit: 2, default: 0, null: false
+  end
+
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -92,6 +92,7 @@ CREATE TABLE public.events (
     end_time timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    status smallint DEFAULT 0 NOT NULL,
     CONSTRAINT chk_rails_2d23c98cce CHECK (((end_time IS NULL) OR (end_time > start_time)))
 );
 
@@ -127,6 +128,7 @@ CREATE TABLE public.offline_meetings (
     event_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    status smallint DEFAULT 0 NOT NULL,
     CONSTRAINT chk_rails_538f471a96 CHECK (((end_time IS NULL) OR (end_time > start_time)))
 );
 
@@ -162,6 +164,7 @@ CREATE TABLE public.online_meetings (
     event_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    status smallint DEFAULT 0 NOT NULL,
     CONSTRAINT chk_rails_d12176be61 CHECK (((end_time IS NULL) OR (end_time > start_time)))
 );
 
@@ -453,6 +456,9 @@ ALTER TABLE ONLY public.online_meetings
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241002173300'),
+('20241002173252'),
+('20241002173107'),
 ('20241001203231'),
 ('20241001203225'),
 ('20241001203219'),

--- a/spec/factories/event_organizers.rb
+++ b/spec/factories/event_organizers.rb
@@ -13,8 +13,8 @@
 # Indexes
 #
 #  index_event_organizers_on_event_id              (event_id)
-#  index_event_organizers_on_event_id_and_user_id  (event_id,user_id) UNIQUE
 #  index_event_organizers_on_user_id               (user_id)
+#  index_event_organizers_on_user_id_and_event_id  (user_id,event_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -8,6 +8,7 @@
 #  description :text             not null
 #  end_time    :datetime
 #  start_time  :datetime         not null
+#  status      :integer          default(0), not null
 #  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -20,6 +21,7 @@ FactoryBot.define do
   factory :event, traits: [ :future ] do
     title { "event-#{Faker::Lorem.sentence(word_count: 3)}" }
     description { Faker::Lorem.paragraph }
+    status { :draft }
 
     # Shared time range traits from 'event_time_range_traits.rb'
     future

--- a/spec/factories/offline_meetings.rb
+++ b/spec/factories/offline_meetings.rb
@@ -7,6 +7,7 @@
 #  id         :bigint           not null, primary key
 #  end_time   :datetime
 #  start_time :datetime         not null
+#  status     :integer          default(0), not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -24,6 +25,7 @@
 FactoryBot.define do
   factory :offline_meeting, traits: [ :future ] do
     title { "offline-meeting-#{Faker::Lorem.sentence(word_count: 3)}" }
+    status { :draft }
 
     association :event
 

--- a/spec/factories/online_meetings.rb
+++ b/spec/factories/online_meetings.rb
@@ -7,6 +7,7 @@
 #  id         :bigint           not null, primary key
 #  end_time   :datetime
 #  start_time :datetime         not null
+#  status     :integer          default(0), not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -24,6 +25,7 @@
 FactoryBot.define do
   factory :online_meeting, traits: [ :future ] do
     title { "online-meeting-#{Faker::Lorem.sentence(word_count: 3)}" }
+    status { :draft }
 
     association :event
 

--- a/spec/models/event_organizer_spec.rb
+++ b/spec/models/event_organizer_spec.rb
@@ -13,8 +13,8 @@
 # Indexes
 #
 #  index_event_organizers_on_event_id              (event_id)
-#  index_event_organizers_on_event_id_and_user_id  (event_id,user_id) UNIQUE
 #  index_event_organizers_on_user_id               (user_id)
+#  index_event_organizers_on_user_id_and_event_id  (user_id,event_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,7 @@
 #  description :text             not null
 #  end_time    :datetime
 #  start_time  :datetime         not null
+#  status      :integer          default(0), not null
 #  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -25,7 +26,17 @@ RSpec.describe Event, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
+    it "defaults to 'draft' status" do
+      expect(event.status).to eq('draft')
+    end
+
     include_examples 'time_range_validations'
+  end
+
+  describe '.statuses' do
+    it "maps correct status values" do
+      expect(Event.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
+    end
   end
 
   describe '#associations' do

--- a/spec/models/offline_meeting_spec.rb
+++ b/spec/models/offline_meeting_spec.rb
@@ -7,6 +7,7 @@
 #  id         :bigint           not null, primary key
 #  end_time   :datetime
 #  start_time :datetime         not null
+#  status     :integer          default(0), not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -30,7 +31,17 @@ RSpec.describe OfflineMeeting, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
+    it "defaults to 'draft' status" do
+      expect(offline_meeting.status).to eq('draft')
+    end
+
     include_examples 'time_range_validations'
+  end
+
+  describe '.statuses' do
+    it "maps correct status values" do
+      expect(OfflineMeeting.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
+    end
   end
 
   describe '#associations' do

--- a/spec/models/online_meeting_spec.rb
+++ b/spec/models/online_meeting_spec.rb
@@ -7,6 +7,7 @@
 #  id         :bigint           not null, primary key
 #  end_time   :datetime
 #  start_time :datetime         not null
+#  status     :integer          default(0), not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -30,7 +31,17 @@ RSpec.describe OnlineMeeting, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
+    it "defaults to 'draft' status" do
+      expect(online_meeting.status).to eq('draft')
+    end
+
     include_examples 'time_range_validations'
+  end
+
+  describe '.statuses' do
+    it "maps correct status values" do
+      expect(OnlineMeeting.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
+    end
   end
 
   describe '#associations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe '#associations' do
-      it { is_expected.to have_many(:event_organizers).inverse_of(:user) }
-      it {
-        is_expected.to have_many(:organized_events).through(:event_organizers).inverse_of(:organizers).source(:event)
-      }
-    end
-
     describe '#full_name' do
       let(:user) { create(:user) }
 
@@ -142,5 +135,18 @@ RSpec.describe User, type: :model do
         end
       end
     end
+  end
+
+  describe '.statuses' do
+    it "maps correct status values" do
+      expect(User.statuses).to eq({ 'pending' => 0, 'active' => 1, 'archived' => 2 })
+    end
+  end
+
+  describe '#associations' do
+    it { is_expected.to have_many(:event_organizers).inverse_of(:user) }
+    it {
+      is_expected.to have_many(:organized_events).through(:event_organizers).inverse_of(:organizers).source(:event)
+    }
   end
 end


### PR DESCRIPTION
Add a status attribute to Event, OnlineMeeting, and OfflineMeeting models to manage their lifecycle states. Update the User model to include a status attribute for better user management. Implement corresponding database migrations and tests to support and verify these changes.

New Features:
- Introduce a status attribute to the Event, OnlineMeeting, and OfflineMeeting models, allowing them to have states such as draft, published, cancelled, and archived
- Update database schema to include status columns for events, online meetings, and offline meetings, ensuring the database structure supports the new status feature
- Ensure that the initial status is 'draft' which will give organizer option to work on their events and meetings before publishing them to public

Enhancements:
- Refactor the User model to include a status attribute with states pending, active, and archived, improving user management capabilities

Tests:
- Add tests to verify the correct mapping of status values for Event, OnlineMeeting, OfflineMeeting, and User models, ensuring the new status functionality works as expected
