### PR TITLE
feat: Introduce simple state machine to handle status transitions

### DIFF
--- a/app/models/concerns/simple_state_machine.rb
+++ b/app/models/concerns/simple_state_machine.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module SimpleStateMachine
+
+  extend ActiveSupport::Concern
+
+  # Requires a constant ALLOWED_STATUS_TRANSITIONS to be defined
+  # Format:
+  #   - FROM -> TO
+  #   - {} - allowed
+  #   - if: -> {} - rule depends on the object state
+  #   - not present - not allowed
+  #
+  # Example:
+  #   ALLOWED_STATUS_TRANSITIONS = {
+  #     draft: {
+  #       published: {}.freeze,
+  #       archived: {}.freeze
+  #     },
+  #     published: {
+  #       draft: { if: ->(event) { event.meetings.none? } }.freeze,
+  #       cancelled: {}.freeze,
+  #       archived: {}.freeze
+  #     },
+  #     cancelled: {
+  #       archived: {}.freeze
+  #     },
+  #     archived: {}.freeze
+  #   }.freeze
+  included do
+    validate :ensure_valid_status_transition, if: :status_changed?
+
+    # Validates if the transition from the old status to the new status is allowed
+    # It checks against the ALLOWED_STATUS_TRANSITIONS constant defined in the model
+    # If the transition is not allowed, it adds an error to the model
+    # This method is called automatically before saving the model if the status has changed
+    #
+    # Example usage:
+    #   user = Event.find(1)
+    #   user.status = :archived
+    #   user.save
+    #   # This might trigger the validation and add an error to the event's errors if this transition is not allowed
+    def ensure_valid_status_transition
+      current_status = status.to_sym
+      old_status = status_was.to_sym
+
+      rule = self.class::ALLOWED_STATUS_TRANSITIONS.dig(old_status, current_status)
+
+      return if rule && rule[:if]&.call(self) != false
+
+      errors.add(:status, :invalid_transition, from: old_status, to: current_status)
+    end
+
+    # Returns an array of allowed status transitions from the current status
+    # It takes into account the rules defined in the `ALLOWED_STATUS_TRANSITIONS` constant
+    # Status is assumed to be valid
+    #
+    # Example usage:
+    #   event = Event.find(1)
+    #   allowed_transitions = event.allowed_transitions
+    #   # This might return [:published, :cancelled, :archived] as allowed transitions
+    def allowed_transitions
+      @allowed_transitions ||= begin
+        current_status = status.to_sym
+        transitions = self.class::ALLOWED_STATUS_TRANSITIONS[current_status] || {}
+
+        transitions.select { |_, rule| rule[:if]&.call(self) != false }.keys
+      end
+    end
+  end
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,18 +96,24 @@ en:
               taken: event is already assigned to this user
         event:
           attributes:
+            status:
+              invalid_transition: 'Cannot transition from %{from} to %{to}'
             start_time:
               invalid_time_range: must be before the end time
             end_time:
               invalid_time_range: must be after the start time
         online_meeting:
           attributes:
+            status:
+              invalid_transition: 'Cannot transition from %{from} to %{to}'
             start_time:
               invalid_time_range: must be before the end time
             end_time:
               invalid_time_range: must be after the start time
         offline_meeting:
           attributes:
+            status:
+              invalid_transition: 'Cannot transition from %{from} to %{to}'
             start_time:
               invalid_time_range: must be before the end time
             end_time:

--- a/spec/models/concerns/simple_state_machine_spec.rb
+++ b/spec/models/concerns/simple_state_machine_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SimpleStateMachine, type: :model do
+  subject(:test_model) { SimpleStateMachineTest.new(status: :draft) }
+
+  before(:all) do
+    ActiveRecord::Base.connection.create_table(:simple_state_machine_tests, force: true) do |t|
+      t.integer :status, default: 0
+    end
+
+    class SimpleStateMachineTest < ActiveRecord::Base
+
+      include SimpleStateMachine
+
+      enum :status, { draft: 0, published: 1, cancelled: 2, archived: 3 }
+
+      ALLOWED_STATUS_TRANSITIONS = {
+        draft: {
+          published: {}.freeze,
+          archived: {}.freeze
+        },
+        published: {
+          draft: { if: ->(test_model) { test_model.can_revert_to_draft? } },
+          cancelled: {}.freeze,
+          archived: {}.freeze
+        },
+        cancelled: {
+          archived: {}.freeze
+        },
+        archived: {}.freeze
+      }.freeze
+
+      def can_revert_to_draft?; true; end
+
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :SimpleStateMachineTest)
+
+    ActiveRecord::Base.connection.drop_table(:simple_state_machine_tests, if_exists: true)
+  end
+
+  describe 'state transitions' do
+    context 'when valid transition' do
+      before { test_model.status = :published }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when invalid transition' do
+      before { test_model.status = :cancelled }
+
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  describe '#allowed_transitions' do
+    before { test_model.status = :published }
+
+    it 'provides correct allowed transitions' do
+      expect(test_model.allowed_transitions).to match_array([ :draft, :cancelled, :archived ])
+    end
+  end
+end

--- a/spec/requests/concerns/error_handler_spec.rb
+++ b/spec/requests/concerns/error_handler_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe 'API Error Handler Concern', type: :request do
+RSpec.describe ErrorHandler, type: :request do
   before(:all) do
     module API
       module V1
-        class TestController < ApplicationController
+        class ErrorHandlerTestController < ApplicationController
 
           include ErrorHandler
 
@@ -19,20 +19,24 @@ RSpec.describe 'API Error Handler Concern', type: :request do
     Rails.application.routes.draw do
       namespace :api do
         namespace :v1 do
-          resources :test, only: [ :index ]
+          resources :error_handler_test, only: [ :index ]
         end
       end
     end
   end
 
-  after(:all) { Rails.application.reload_routes! }
+  after(:all) do
+    Rails.application.reload_routes!
+
+    API::V1.send(:remove_const, :ErrorHandlerTestController)
+  end
 
   describe 'Error handlers' do
     shared_examples 'error handler' do |error_class, status, message_key|
       before do
-        allow_any_instance_of(API::V1::TestController).to receive(:index).and_raise(error_class)
+        allow_any_instance_of(API::V1::ErrorHandlerTestController).to receive(:index).and_raise(error_class)
 
-        get '/api/v1/test'
+        get '/api/v1/error_handler_test'
       end
 
       it "handles #{error_class} correctly" do

--- a/spec/requests/concerns/versionable_spec.rb
+++ b/spec/requests/concerns/versionable_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe "API Versionable Concern", type: :request do
+RSpec.describe Versionable, type: :request do
   before(:all) do
     module API
       module V1
-        class TestVersionableController < ApplicationController
+        class VersionableTestController < ApplicationController
 
           include Versionable
 
@@ -18,10 +18,10 @@ RSpec.describe "API Versionable Concern", type: :request do
 
     Rails.application.routes.draw do
       namespace :api do
-        get 'v2/test_versionable', action: :index, controller: 'v1/test_versionable'
+        get 'v2/versionable_test', action: :index, controller: 'v1/versionable_test'
 
         namespace :v1 do
-          get '/test_versionable', to: 'test_versionable#index'
+          get '/versionable_test', to: 'versionable_test#index'
         end
       end
     end
@@ -29,11 +29,13 @@ RSpec.describe "API Versionable Concern", type: :request do
 
   after(:all) do
     Rails.application.reload_routes!
+
+    API::V1.send(:remove_const, :VersionableTestController)
   end
 
   context 'when valid version' do
     it 'returns success' do
-      get '/api/v1/test_versionable'
+      get '/api/v1/versionable_test'
 
       expect(response).to have_http_status(:success)
       expect(json_symbolize[:message]).to eq("API version is v1")
@@ -43,7 +45,7 @@ RSpec.describe "API Versionable Concern", type: :request do
   context 'when invalid version' do
     it 'returns API version mismatch error' do
       expect {
-        get '/api/v2/test_versionable'
+        get '/api/v2/versionable_test'
       }.to raise_error(Versionable::APIVersionMismatchError)
     end
   end


### PR DESCRIPTION
- Introduce a simple state machine module to handle status transitions, allowing for validation of status changes based on predefined rules
- Add validation messages for invalid status transitions in the locale configuration
- Add tests for state machine
- Update test routes and controllers in error handler and versionable specs to reflect new naming conventions.