### PR TITLE
test: Presence and inclusion validation for Event status

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,7 @@ class Event < ApplicationRecord
 
   # Validations
   validates :title, :start_time, presence: true
+  validates :status, presence: true, inclusion: { in: statuses.keys }
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true
 

--- a/app/models/offline_meeting.rb
+++ b/app/models/offline_meeting.rb
@@ -34,6 +34,7 @@ class OfflineMeeting < ApplicationRecord
 
   # Validations
   validates :title, :start_time, presence: true
+  validates :status, presence: true, inclusion: { in: statuses.keys }
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true
 

--- a/app/models/online_meeting.rb
+++ b/app/models/online_meeting.rb
@@ -34,6 +34,7 @@ class OnlineMeeting < ApplicationRecord
 
   # Validations
   validates :title, :start_time, presence: true
+  validates :status, presence: true, inclusion: { in: statuses.keys }
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -26,15 +26,12 @@ RSpec.describe Event, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
-    it "defaults to 'draft' status" do
-      expect(event.status).to eq('draft')
-    end
-
-    include_examples 'time_range_validations'
+    include_examples 'status validations'
+    include_examples 'time range validations'
   end
 
   describe '.statuses' do
-    it "maps correct status values" do
+    it 'maps correct status values' do
       expect(Event.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
     end
   end
@@ -44,22 +41,5 @@ RSpec.describe Event, type: :model do
     it { is_expected.to have_many(:organizers).through(:event_organizers).inverse_of(:organized_events).source(:user) }
     it { is_expected.to have_many(:online_meetings).dependent(:destroy).inverse_of(:event) }
     it { is_expected.to have_many(:offline_meetings).dependent(:destroy).inverse_of(:event) }
-  end
-
-  describe 'event types' do
-    context 'when both online and offline meetings' do
-      xit 'reports hybrid event type' do
-      end
-    end
-
-    context 'when only online meetings' do
-      xit 'reports online event type' do
-      end
-    end
-
-    context 'when only offline event' do
-      xit 'reports offline event type' do
-      end
-    end
   end
 end

--- a/spec/models/offline_meeting_spec.rb
+++ b/spec/models/offline_meeting_spec.rb
@@ -31,15 +31,12 @@ RSpec.describe OfflineMeeting, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
-    it "defaults to 'draft' status" do
-      expect(offline_meeting.status).to eq('draft')
-    end
-
-    include_examples 'time_range_validations'
+    include_examples 'status validations'
+    include_examples 'time range validations'
   end
 
   describe '.statuses' do
-    it "maps correct status values" do
+    it 'maps correct status values' do
       expect(OfflineMeeting.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
     end
   end

--- a/spec/models/online_meeting_spec.rb
+++ b/spec/models/online_meeting_spec.rb
@@ -31,15 +31,12 @@ RSpec.describe OnlineMeeting, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:start_time) }
 
-    it "defaults to 'draft' status" do
-      expect(online_meeting.status).to eq('draft')
-    end
-
-    include_examples 'time_range_validations'
+    include_examples 'status validations'
+    include_examples 'time range validations'
   end
 
   describe '.statuses' do
-    it "maps correct status values" do
+    it 'maps correct status values' do
       expect(OnlineMeeting.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
     end
   end

--- a/spec/support/shared_examples/status_validations.rb
+++ b/spec/support/shared_examples/status_validations.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'status validations' do
+  it { is_expected.to validate_presence_of(:status) }
+
+  it "defaults to 'draft' status" do
+    expect(subject.status).to eq('draft')
+  end
+
+  it 'is expected to be valid for all defined statuses' do
+    subject.class.statuses.keys.each do |valid_status|
+      subject.status = valid_status
+      expect(subject).to be_valid
+    end
+  end
+
+  it "is expected to be invalid for 'invalid_status' status value" do
+    expect { subject.status = 'invalid_status' }.to raise_error(ArgumentError)
+  end
+
+  it "is expected to be invalid for 'nil' value" do
+    subject.status = nil
+    expect(subject).to be_invalid
+  end
+end

--- a/spec/support/shared_examples/time_range_validations.rb
+++ b/spec/support/shared_examples/time_range_validations.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# spec/support/shared_examples/time_range_validations.rb
-
-RSpec.shared_examples 'time_range_validations' do
+RSpec.shared_examples 'time range validations' do
   let(:model_name) { described_class.to_s.underscore }
 
   describe 'time range validations' do


### PR DESCRIPTION
- Add presence and inclusion validation for the status attribute in Event, OfflineMeeting, and OnlineMeeting models
- Introduce shared examples for status validations to ensure consistent validation across Event, OfflineMeeting, and OnlineMeeting models
- Remove pending tests for event types in the Event model spec