### PR TITLE
feat: Introduce state machine to manage Event model status transitions

### DIFF
--- a/app/models/concerns/simple_state_machine.rb
+++ b/app/models/concerns/simple_state_machine.rb
@@ -28,8 +28,6 @@ module SimpleStateMachine
   #     archived: {}.freeze
   #   }.freeze
   included do
-    validate :ensure_valid_status_transition, if: :status_changed?
-
     # Validates if the transition from the old status to the new status is allowed
     # It checks against the ALLOWED_STATUS_TRANSITIONS constant defined in the model
     # If the transition is not allowed, it adds an error to the model

--- a/app/models/online_meeting.rb
+++ b/app/models/online_meeting.rb
@@ -26,6 +26,24 @@ class OnlineMeeting < ApplicationRecord
 
   # TODO: Add support for setting up online meeting using services like Zoom, Google meet and Microsoft teams
 
+  include SimpleStateMachine
+
+  ALLOWED_STATUS_TRANSITIONS = {
+    draft: {
+      published: {}.freeze,
+      archived: {}.freeze
+    },
+    published: {
+      draft: { if: ->(meeting) { !meeting.event.published? } }.freeze,
+      cancelled: {}.freeze,
+      archived: {}.freeze
+    },
+    cancelled: {
+      archived: {}.freeze
+    },
+    archived: {}.freeze
+  }.freeze
+
   # Associations
   belongs_to :event, inverse_of: :online_meetings
 
@@ -37,5 +55,7 @@ class OnlineMeeting < ApplicationRecord
   validates :status, presence: true, inclusion: { in: statuses.keys }
   validates :end_time, allow_nil: true, time_range: true
   validates :start_time, time_range: true
+
+  validate :ensure_valid_status_transition, on: :update, if: :status_changed?
 
 end

--- a/spec/models/concerns/simple_state_machine_spec.rb
+++ b/spec/models/concerns/simple_state_machine_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SimpleStateMachine, type: :model do
-  subject(:test_model) { SimpleStateMachineTest.new(status: :draft) }
+  subject(:test_model) { SimpleStateMachineTest.create(status: :draft) }
 
   before(:all) do
     ActiveRecord::Base.connection.create_table(:simple_state_machine_tests, force: true) do |t|
@@ -13,8 +13,6 @@ RSpec.describe SimpleStateMachine, type: :model do
     class SimpleStateMachineTest < ActiveRecord::Base
 
       include SimpleStateMachine
-
-      enum :status, { draft: 0, published: 1, cancelled: 2, archived: 3 }
 
       ALLOWED_STATUS_TRANSITIONS = {
         draft: {
@@ -31,6 +29,10 @@ RSpec.describe SimpleStateMachine, type: :model do
         },
         archived: {}.freeze
       }.freeze
+
+      enum :status, { draft: 0, published: 1, cancelled: 2, archived: 3 }
+
+      validate :ensure_valid_status_transition, on: :update, if: :status_changed?
 
       def can_revert_to_draft?; true; end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Event, type: :model do
 
   describe '#validations' do
     it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to validate_presence_of(:start_time) }
 
     include_examples 'status validations'
@@ -31,15 +32,124 @@ RSpec.describe Event, type: :model do
   end
 
   describe '.statuses' do
-    it 'maps correct status values' do
-      expect(Event.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
-    end
+    it { is_expected.to define_enum_for(:status).with_values(draft: 0, published: 1, cancelled: 2, archived: 3) }
   end
 
   describe '#associations' do
     it { is_expected.to have_many(:event_organizers).inverse_of(:event) }
-    it { is_expected.to have_many(:organizers).through(:event_organizers).inverse_of(:organized_events).source(:user) }
+    it { is_expected.to have_many(:organizers).through(:event_organizers).source(:user).inverse_of(:organized_events) }
     it { is_expected.to have_many(:online_meetings).dependent(:destroy).inverse_of(:event) }
     it { is_expected.to have_many(:offline_meetings).dependent(:destroy).inverse_of(:event) }
+  end
+
+  describe '#has_published_meetings?' do
+    let(:event) { create(:event) }
+
+    where(:case_name, :online_meeting_status, :offline_meeting_status, :expected_result) do
+      [
+        [ 'when published online meeting',                    :published,   nil,        true ],
+        [ 'when published offline meeting',                   nil,          :published, true ],
+        [ 'when both published online and offline meetings',  :published,   :published, true ],
+        [ 'when no meetings',                                 nil,          nil,        false ],
+        [ 'when all unpublished meetings',                    :draft,       :draft,     false ],
+        [ 'when only one published meeting',                  :published,   :draft,     true ]
+      ]
+    end
+
+    with_them do
+      before do
+        create(:online_meeting, event:, status: online_meeting_status) if online_meeting_status
+        create(:offline_meeting, event:, status: offline_meeting_status) if offline_meeting_status
+      end
+
+      it { expect(event.has_published_meetings?).to eq(expected_result) }
+    end
+  end
+
+  describe 'state machine transitions' do
+    using RSpec::Parameterized::TableSyntax
+
+    let(:expected_error_message) do
+      lambda do |from, to|
+        I18n.t(
+          'activerecord.errors.models.event.attributes.status.invalid_transition',
+          from:,
+          to:
+        )
+      end
+    end
+
+    context 'valid transitions' do
+      where(:case_name, :from_state, :to_state) do
+        [
+          [ 'from draft to published',      :draft,     :published ],
+          [ 'from draft to archived',       :draft,     :archived ],
+          [ 'from published to cancelled',  :published, :cancelled ],
+          [ 'from published to archived',   :published, :archived ],
+          [ 'from cancelled to archived',   :cancelled, :archived ]
+        ]
+      end
+
+      with_them do
+        let(:event) { create(:event, status: from_state) }
+
+        before { event.status = to_state }
+
+        it { expect(event).to be_valid }
+      end
+
+      context 'when there are no published meetings' do
+        let(:event) { create(:event, status: :published) }
+
+        before do
+          allow(event).to receive(:has_published_meetings?).and_return(false)
+
+          event.status = :draft
+        end
+
+        it 'allows transition from published to draft' do
+          expect(event).to be_valid
+        end
+      end
+    end
+
+    context 'invalid transitions' do
+      where(:case_name, :from_state, :to_state) do
+        [
+          [ 'from draft to cancelled',     :draft,     :cancelled ],
+          [ 'from cancelled to draft',     :cancelled, :draft ],
+          [ 'from cancelled to published', :cancelled, :published ],
+          [ 'from archived to draft',      :archived,  :draft ],
+          [ 'from archived to published',  :archived,  :published ],
+          [ 'from archived to cancelled',  :archived,  :cancelled ]
+        ]
+      end
+
+      with_them do
+        let(:event) { create(:event, status: from_state) }
+
+        before { event.status = to_state }
+
+        it do
+          expect(event).not_to be_valid
+          expect(event.errors[:status]).to include(expected_error_message.call(from_state, to_state))
+        end
+      end
+
+      context 'when there are published meetings' do
+        let(:event) { create(:event, status: :published) }
+
+        before do
+          allow(event).to receive(:has_published_meetings?).and_return(true)
+
+          event.status = :draft
+        end
+
+        it 'disallows transition from published to draft' do
+          expect(event).not_to be_valid
+          expect(event.errors[:status]).to include(expected_error_message.call(:published, :draft))
+        end
+      end
+    end
   end
 end

--- a/spec/models/online_meeting_spec.rb
+++ b/spec/models/online_meeting_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe OnlineMeeting, type: :model do
 
   describe '#validations' do
     it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to validate_presence_of(:start_time) }
 
     include_examples 'status validations'
@@ -36,12 +37,91 @@ RSpec.describe OnlineMeeting, type: :model do
   end
 
   describe '.statuses' do
-    it 'maps correct status values' do
-      expect(OnlineMeeting.statuses).to eq({ 'draft' => 0, 'published' => 1, 'cancelled' => 2, 'archived' => 3 })
-    end
+    it { is_expected.to define_enum_for(:status).with_values(draft: 0, published: 1, cancelled: 2, archived: 3) }
   end
 
   describe '#associations' do
     it { is_expected.to belong_to(:event).inverse_of(:online_meetings) }
+  end
+
+  describe 'state machine transitions' do
+    using RSpec::Parameterized::TableSyntax
+
+    let(:expected_error_message) do
+      lambda do |from, to|
+        I18n.t(
+          'activerecord.errors.models.online_meeting.attributes.status.invalid_transition',
+          from:,
+          to:
+        )
+      end
+    end
+
+    context 'valid transitions' do
+      where(:case_name, :from_state, :to_state) do
+        [
+          [ 'from draft to published',      :draft,     :published ],
+          [ 'from draft to archived',       :draft,     :archived ],
+          [ 'from published to cancelled',  :published, :cancelled ],
+          [ 'from published to archived',   :published, :archived ],
+          [ 'from cancelled to archived',   :cancelled, :archived ]
+        ]
+      end
+
+      with_them do
+        let(:online_meeting) { create(:online_meeting, status: from_state) }
+
+        before { online_meeting.status = to_state }
+
+        it { expect(online_meeting).to be_valid }
+      end
+
+      context 'when event is not published yet' do
+        let(:event) { create(:event, status: :draft) }
+        let(:online_meeting) { create(:online_meeting, event:, status: :published) }
+
+        before { online_meeting.status = :draft }
+
+        it 'allows transition from published to draft' do
+          expect(online_meeting).to be_valid
+        end
+      end
+    end
+
+    context 'invalid transitions' do
+      where(:case_name, :from_state, :to_state) do
+        [
+          [ 'from draft to cancelled',     :draft,     :cancelled ],
+          [ 'from cancelled to draft',     :cancelled, :draft ],
+          [ 'from cancelled to published', :cancelled, :published ],
+          [ 'from archived to draft',      :archived,  :draft ],
+          [ 'from archived to published',  :archived,  :published ],
+          [ 'from archived to cancelled',  :archived,  :cancelled ]
+        ]
+      end
+
+      with_them do
+        let(:online_meeting) { create(:online_meeting, status: from_state) }
+
+        before { online_meeting.status = to_state }
+
+        it do
+          expect(online_meeting).not_to be_valid
+          expect(online_meeting.errors[:status]).to include(expected_error_message.call(from_state, to_state))
+        end
+      end
+
+      context 'when event is already published' do
+        let(:event) { create(:event, status: :published) }
+        let(:online_meeting) { create(:online_meeting, event:, status: :published) }
+
+        before { online_meeting.status = :draft }
+
+        it 'disallows transition from published to draft' do
+          expect(online_meeting).not_to be_valid
+          expect(online_meeting.errors[:status]).to include(expected_error_message.call(:published, :draft))
+        end
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/status_validations.rb
+++ b/spec/support/shared_examples/status_validations.rb
@@ -7,19 +7,13 @@ RSpec.shared_examples 'status validations' do
     expect(subject.status).to eq('draft')
   end
 
-  it 'is expected to be valid for all defined statuses' do
-    subject.class.statuses.keys.each do |valid_status|
-      subject.status = valid_status
-      expect(subject).to be_valid
-    end
-  end
-
   it "is expected to be invalid for 'invalid_status' status value" do
     expect { subject.status = 'invalid_status' }.to raise_error(ArgumentError)
   end
 
   it "is expected to be invalid for 'nil' value" do
     subject.status = nil
+
     expect(subject).to be_invalid
   end
 end


### PR DESCRIPTION
Introduce a simple state machine to manage status transitions for Event, Online, and Offline meeting models, and add corresponding validations and tests to ensure correct behavior.

- Introduce a simple state machine to manage status transitions for Event, Online, and Offline meeting models
- Add validation to ensure valid status transitions for Event, Online, and Offline meeting models
- Add tests for state machine transitions, including valid and invalid status changes for Event, Online, and Offline meeting models
- Include parameterized tests to verify the behavior of status transitions under various conditions