### PR TITLE
feat: Add V1 API to get single Event

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -22,3 +22,6 @@ directories:
   'app/validators':
     UtilityFunction:
       enabled: false
+  'spec/support':
+    UtilityFunction:
+      enabled: false

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -12,4 +12,12 @@ class API::V1::EventsController < API::V1::BaseController
     render json: API::V1::EventSerializer.new(events).serialize
   end
 
+  def show
+    id = params.require(:id).to_i
+
+    event = Event.find(id)
+
+    render json: API::V1::EventSerializer.new(event).serialize
+  end
+
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
           index: Paginated list of users for platform administration
         events:
           index: Paginated list of events
+          show: Get single event
       models:
         user:
           id:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
       resources :users, only: [ :index ]
-      resources :events, only: [ :index ]
+      resources :events, only: [ :index, :show ]
 
       # This must be the last route definition under the namespace
       # to catch-all route to handle missing routes

--- a/docs/api_guide/v1/open_api.yaml
+++ b/docs/api_guide/v1/open_api.yaml
@@ -36,6 +36,28 @@ paths:
                 type: array
                 items:
                   '$ref': '#/components/schemas/event'
+  '/api/v1/events/{event_id}':
+    get:
+      summary: Get single event
+      tags:
+        - Event
+      parameters:
+        - '$ref': '#/components/parameters/event_id'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              example:
+                id: 1
+                title: Ruby Meetup - November 2024
+                description: Ruby developer group's monthly meetup
+                status: published
+                startTime: '2024-11-25T10:00:25Z'
+                createdAt: '2024-10-25T10:00:25Z'
+                updatedAt: '2024-10-26T06:12:31Z'
+              schema:
+                '$ref': '#/components/schemas/event'
   '/api/v1/users':
     get:
       summary: Paginated list of users for platform administration
@@ -78,6 +100,14 @@ servers:
       defaultHost:
         default: www.example.com
 components:
+  parameters:
+    event_id:
+      name: event_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Unique identifier for the event
   schemas:
     error:
       type: object

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -22,40 +22,72 @@ RSpec.describe API::V1::EventsController, type: :request do
 
       response 200, I18n.t('api.v1.response.ok') do
         after do |example|
-          content = example.metadata.dig(:response, :content) || {}
-
-          example_spec = {
-            Mime[:json].to_s => {
-              example: [
-                {
-                  id: 1,
-                  title: 'Ruby Meetup - October 2024',
-                  description: "Ruby developer group's monthly meetup",
-                  status: 'published',
-                  startTime: '2024-10-25T10:00:25Z',
-                  createdAt: '2024-09-25T10:00:25Z',
-                  updatedAt: '2024-09-26T06:12:31Z'
-                },
-                {
-                  id: 2,
-                  title: 'Ruby Meetup - November 2024',
-                  description: "Ruby developer group's monthly meetup",
-                  status: 'draft',
-                  startTime: '2024-11-25T10:00:25Z',
-                  endTime: '2024-11-25T10:00:25Z',
-                  createdAt: '2024-10-25T10:00:25Z',
-                  updatedAt: '2024-10-26T06:12:31Z'
-                }
-              ]
+          example_data = [
+            {
+              id: 1,
+              title: 'Ruby Meetup - October 2024',
+              description: "Ruby developer group's monthly meetup",
+              status: 'published',
+              startTime: '2024-10-25T10:00:25Z',
+              createdAt: '2024-09-25T10:00:25Z',
+              updatedAt: '2024-09-26T06:12:31Z'
+            },
+            {
+              id: 2,
+              title: 'Ruby Meetup - November 2024',
+              description: "Ruby developer group's monthly meetup",
+              status: 'draft',
+              startTime: '2024-11-25T10:00:25Z',
+              endTime: '2024-11-25T10:00:25Z',
+              createdAt: '2024-10-25T10:00:25Z',
+              updatedAt: '2024-10-26T06:12:31Z'
             }
-          }
+          ]
 
-          example.metadata[:response][:content] = content.deep_merge(example_spec)
+          add_response_example(example, example_data)
         end
 
         schema type: :array, items: { '$ref' => '#/components/schemas/event' }
 
         run_test! do
+          expect(json).to eq(expected_data)
+        end
+      end
+    end
+  end
+
+  path '/api/v1/events/{event_id}' do
+    let!(:event) { create(:event, :future, status: :published) }
+    let(:event_id) { event.id }
+
+    let(:expected_data) { JSON.parse(API::V1::EventSerializer.new(event).serialize) }
+
+    get I18n.t('api.v1.endpoints.events.show') do
+      produces Mime[:json].to_s
+
+      tags Event.to_s
+
+      parameter '$ref' => '#/components/parameters/event_id'
+
+      response 200, I18n.t('api.v1.response.ok') do
+        after do |example|
+          example_data = {
+            id: 1,
+            title: 'Ruby Meetup - November 2024',
+            description: "Ruby developer group's monthly meetup",
+            status: 'published',
+            startTime: '2024-11-25T10:00:25Z',
+            createdAt: '2024-10-25T10:00:25Z',
+            updatedAt: '2024-10-26T06:12:31Z'
+          }
+
+          add_response_example(example, example_data)
+        end
+
+        schema '$ref' => '#/components/schemas/event'
+
+        run_test! do
+          puts "json: #{json}"
           expect(json).to eq(expected_data)
         end
       end

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -15,43 +15,37 @@ RSpec.describe API::V1::UsersController, type: :request do
 
       response 200, I18n.t('api.v1.response.ok') do
         after do |example|
-          content = example.metadata.dig(:response, :content) || {}
-
-          example_spec = {
-            Mime[:json].to_s => {
-              example: [
-                {
-                  id: 1,
-                  email: "john@smith.example",
-                  firstName: "John",
-                  lastName: "Smith",
-                  fullName: "John Smith",
-                  status: "active",
-                  preferences: {
-                    theme: 'system'
-                  },
-                  createdAt: "2024-09-25T10:00:25Z",
-                  updatedAt: "2024-09-26T06:12:31Z"
-                },
-                {
-                  id: 2,
-                  email: "bruce@wayne.batman",
-                  firstName: "Bruce",
-                  lastName: "Wayne",
-                  fullName: "Bruce Wayne",
-                  status: "archived",
-                  archivalReason: 'Some reason for account archival',
-                  preferences: {
-                    theme: 'dark'
-                  },
-                  createdAt: "2024-09-26T01:20:00Z",
-                  updatedAt: "2024-09-26T06:30:30Z"
-                }
-              ]
+          example_data = [
+            {
+              id: 1,
+              email: "john@smith.example",
+              firstName: "John",
+              lastName: "Smith",
+              fullName: "John Smith",
+              status: "active",
+              preferences: {
+                theme: 'system'
+              },
+              createdAt: "2024-09-25T10:00:25Z",
+              updatedAt: "2024-09-26T06:12:31Z"
+            },
+            {
+              id: 2,
+              email: "bruce@wayne.batman",
+              firstName: "Bruce",
+              lastName: "Wayne",
+              fullName: "Bruce Wayne",
+              status: "archived",
+              archivalReason: 'Some reason for account archival',
+              preferences: {
+                theme: 'dark'
+              },
+              createdAt: "2024-09-26T01:20:00Z",
+              updatedAt: "2024-09-26T06:30:30Z"
             }
-          }
+          ]
 
-          example.metadata[:response][:content] = content.deep_merge(example_spec)
+          add_response_example(example, example_data)
         end
 
         schema type: :array, items: { '$ref' => '#/components/schemas/user' }

--- a/spec/support/swagger_helpers.rb
+++ b/spec/support/swagger_helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SwaggerHelpers
+
+  # Add response examples to Swagger documentation
+  # Usage:
+  #   response 200, 'success' do
+  #     after do |example|
+  #       example_data = {a: 1, b: 2}
+  #       add_response_example(example, example_data)
+  #     end
+  #   end
+  def add_response_example(example, example_data)
+    metadata = example.metadata
+    content = metadata.dig(:metadata, :response, :content) || {}
+
+    json_mime = Mime[:json].to_s
+
+    example_spec = {
+      json_mime => {
+        example: example_data
+      }
+    }
+
+    metadata[:response][:content] = content.deep_merge(example_spec)
+  end
+
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.configure do |config|
+  config.include SwaggerHelpers
+
   config.openapi_root = Rails.root.join('docs', 'api_guide').to_s
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
@@ -37,6 +39,17 @@ RSpec.configure do |config|
         }
       ],
       components: {
+        parameters: {
+          event_id: {
+            name: :event_id,
+            in: :path,
+            required: true,
+            schema: {
+              type: :string
+            },
+            description: I18n.t('api.v1.models.event.id.description')
+          }
+        },
         schemas: {
           error: {
             type: :object,


### PR DESCRIPTION
- Introduce a new API endpoint to retrieve a single event by its ID in the V1 API
- Refactor test examples to use a helper method for adding response examples in Swagger documentation
- Update Open API documentation to include the new endpoint for fetching a single event
- Add test cases for the new API endpoint to retrieve a single event